### PR TITLE
decompressDependencyFiles: ensure destination file is not a directory

### DIFF
--- a/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
@@ -88,7 +88,7 @@ public final class JarUtils {
         File destinationParent = destFile.getParentFile();
         // create the parent directory structure if needed
         destinationParent.mkdirs();
-        if (!entry.isDirectory()) {
+        if (!entry.isDirectory() && !destFile.isDirectory()) {
           BufferedInputStream is = new BufferedInputStream(zip.getInputStream(entry));
           int currentByte;
           // establish buffer for writing file


### PR DESCRIPTION
Think of a Maven project where target folder contains some dependency **dep-1.2.3** and under that a **META-INF** directory exists. Under **META-INF** directory there's a folder named **license** which contains several other files. When depclean is run on that project, there is an exception being logged and the error message tells that the aforementioned **license** directory "is a directory", indeed it is.
The stack trace of the exception points to **se.kth.depclean.core.util.JarUtils.decompressDependencyFiles**.
The change in this PR helped get rid of that error.