### PR TITLE
feat: upgrade to Java 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,10 +84,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1.1.0
-
-      - name: Java 21
+      - name: Set up Java 21
         uses: actions/setup-java@v4
         with:
           java-version: 21
@@ -100,23 +97,15 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2-
-
-      # solving issues with current working directory
-      # working-directory: ~/depclean-gradle-plugin
-      # with:
-      #   files: ./depclean-gradle-plugin
-      #   path: ~/depclean-gradle-plugin
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Build with maven (Getting missing dependencies)
-        run: mvn clean install -q
+        run: mvn clean install -DskipTests -q
 
       - name: Build with Gradle
+        working-directory: ./depclean-gradle-plugin
         run: |
-          # home is not the repoistory root but `/home/runner`, so chdir to repository root and then use relative paths to current repository root
-          # getting correct directory now
-          # getting executable permission error on the binary
-
-          chmod +x ./depclean-gradle-plugin/gradlew
-          ./depclean-gradle-plugin/gradlew build -p ./depclean-gradle-plugin/ -x test
+          git update-index --chmod=+x gradlew
+          ./gradlew build -x test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,21 +12,21 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ 17 ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        java: [21]
     runs-on: ${{ matrix.os }}
     name: Maven Build with Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:
-
       - name: "Checkout"
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: "temurin"
 
       - name: "Cache Local Maven Repository"
         uses: actions/cache@v3
@@ -47,13 +47,13 @@ jobs:
       - name: "Integration Tests"
         run: mvn failsafe:integration-test --errors --fail-at-end
 
-        # The following is only executed on Ubuntu on Java 17
+        # The following is only executed on Ubuntu on Java 21
       - name: "JaCoCo Coverage Report"
-        if: matrix.os == 'ubuntu-latest' && matrix.java == 17 && github.repository == 'castor-software/depclean'
+        if: matrix.os == 'ubuntu-latest' && matrix.java == 21 && github.repository == 'castor-software/depclean'
         run: mvn jacoco:report
 
       - name: "Codecov"
-        if: matrix.os == 'ubuntu-latest' && matrix.java == 17 && github.repository == 'castor-software/depclean'
+        if: matrix.os == 'ubuntu-latest' && matrix.java == 21 && github.repository == 'castor-software/depclean'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
           flags: unittests
 
       - name: "Cache SonarCloud"
-        if: matrix.os == 'ubuntu-latest' && matrix.java == 17 && github.repository == 'castor-software/depclean'
+        if: matrix.os == 'ubuntu-latest' && matrix.java == 21 && github.repository == 'castor-software/depclean'
         uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
@@ -69,31 +69,29 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
 
       - name: "SonarCloud"
-        if: matrix.os == 'ubuntu-latest' && matrix.java == 17 && github.repository == 'castor-software/depclean'
-        run: mvn sonar:sonar -Dsonar.projectKey=castor-software_depclean -Dsonar.organization=castor-software -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_TOKEN }} -Dsonar.java.source=17 -Dsonar.java.target=17
+        if: matrix.os == 'ubuntu-latest' && matrix.java == 21 && github.repository == 'castor-software/depclean'
+        run: mvn sonar:sonar -Dsonar.projectKey=castor-software_depclean -Dsonar.organization=castor-software -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${{ secrets.SONAR_TOKEN }} -Dsonar.java.source=21 -Dsonar.java.target=21
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-# --------------------------------------------------------------------------------------------------------------------
-# For Gradle module
+  # --------------------------------------------------------------------------------------------------------------------
+  # For Gradle module
   gradle:
-
-    name: Gradle build with Java 17 on ubuntu-latest
+    name: Gradle build with Java 21 on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1.1.0
 
-      - name: Java 17
-        uses: actions/setup-java@v3
+      - name: Java 21
+        uses: actions/setup-java@v4
         with:
-          java-version: 17
-          distribution: 'adopt-hotspot'
+          java-version: 21
+          distribution: "temurin"
 
       - name: Cache Gradle packages
         uses: actions/cache@v3.4.3
@@ -122,4 +120,3 @@ jobs:
 
           chmod +x ./depclean-gradle-plugin/gradlew
           ./depclean-gradle-plugin/gradlew build -p ./depclean-gradle-plugin/ -x test
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch:
     inputs:
       previousVersion:
-        description: 'Previous version'
+        description: "Previous version"
         required: true
       newVersion:
-        description: 'New version'
+        description: "New version"
         required: true
 jobs:
   release:
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Java and Maven
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt-hotspot'
-          java-version: 17
+          distribution: "temurin"
+          java-version: 21
           server-id: ossrh
           server-username: OSSRH_USERNAME # env variable for username in deploy
           server-password: OSSRH_TOKEN # env variable for token in deploy

--- a/README.md
+++ b/README.md
@@ -15,19 +15,6 @@
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=ASSERT-KTH_depclean&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=ASSERT-KTH_depclean)
 [![codecov](https://codecov.io/gh/ASSERT-KTH/depclean/graph/badge.svg?token=X0XE6R72OD)](https://codecov.io/gh/ASSERT-KTH/depclean)
 
-## Features
-
-- Detects and removes all the unused dependencies declared in the `pom.xml` file of a project or imported from its parent
-- Supports Java 21 bytecode analysis, ensuring compatibility with the latest Java features
-- Creates a clean `pom.xml` without unused dependencies
-- Computes a detailed dependency usage report per dependency
-- Fine-grained configuration to customize the dependency analysis and cleaning
-- Can be integrated directly into the Maven build lifecycle
-- Supports multi-module Maven projects
-- Detects unused dependencies in the following scopes: `compile`, `provided`, `test`, `runtime`
-- Ignores dependencies used exclusively through reflection
-- Includes dependencies for Java annotation processing
-- Supports the analysis of fat-jars, shaded dependencies, and repackaged dependencies
 
 ## What is DepClean?
 
@@ -36,6 +23,19 @@ It removes all the dependencies that are included in the project's dependency tr
 DepClean detects and removes all the unused dependencies declared in the `pom.xml` file of a project or imported from its parent.
 It can be executed as a Maven goal through the command line or integrated directly into the Maven build lifecycle (CI/CD).
 DepClean does not modify the original source code of the application nor its original `pom.xml`. It has been presented in ["A Comprehensive Study of Bloated Dependencies in the Maven Ecosystem](http://arxiv.org/pdf/2001.07808") ([doi:10.1007/s10664-020-09914-8](https://doi.org/10.1007/s10664-020-09914-8)).
+
+### Features
+
+- Detects and removes all the unused dependencies declared in the `pom.xml` file of a project or imported from its parent.
+- Supports Java 21 bytecode analysis, ensuring compatibility with the latest Java features.
+- Creates a clean `pom.xml` without unused dependencies.
+- Computes a detailed dependency usage report per dependency.
+- Fine-grained configuration to customize the dependency analysis and cleaning.
+- Can be integrated directly into the Maven build lifecycle.
+- Supports multi-module Maven projects.
+- Ignores dependencies used exclusively through reflection.
+- Includes dependencies for Java annotation processing.
+- Supports the analysis of fat-jars, shaded dependencies, and repackaged dependencies.
 
 For a visual illustration of what DepClean can provide for your project, have a look at the companion [depclean-web](https://github.com/castor-software/depclean-web) project.
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,25 @@
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=ASSERT-KTH_depclean&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=ASSERT-KTH_depclean)
 [![codecov](https://codecov.io/gh/ASSERT-KTH/depclean/graph/badge.svg?token=X0XE6R72OD)](https://codecov.io/gh/ASSERT-KTH/depclean)
 
+## Features
+
+- Detects and removes all the unused dependencies declared in the `pom.xml` file of a project or imported from its parent
+- Supports Java 21 bytecode analysis, ensuring compatibility with the latest Java features
+- Creates a clean `pom.xml` without unused dependencies
+- Computes a detailed dependency usage report per dependency
+- Fine-grained configuration to customize the dependency analysis and cleaning
+- Can be integrated directly into the Maven build lifecycle
+- Supports multi-module Maven projects
+- Detects unused dependencies in the following scopes: `compile`, `provided`, `test`, `runtime`
+- Ignores dependencies used exclusively through reflection
+- Includes dependencies for Java annotation processing
+- Supports the analysis of fat-jars, shaded dependencies, and repackaged dependencies
+
 ## What is DepClean?
 
 DepClean automatically cleans the dependency tree of Java projects.
-It removes all the dependencies that are included in the project's dependency tree but are not actually necessary to build it. 
-DepClean detects and removes all the unused dependencies declared in the `pom.xml` file of a project or imported from its parent. 
+It removes all the dependencies that are included in the project's dependency tree but are not actually necessary to build it.
+DepClean detects and removes all the unused dependencies declared in the `pom.xml` file of a project or imported from its parent.
 It can be executed as a Maven goal through the command line or integrated directly into the Maven build lifecycle (CI/CD).
 DepClean does not modify the original source code of the application nor its original `pom.xml`. It has been presented in ["A Comprehensive Study of Bloated Dependencies in the Maven Ecosystem](http://arxiv.org/pdf/2001.07808") ([doi:10.1007/s10664-020-09914-8](https://doi.org/10.1007/s10664-020-09914-8)).
 
@@ -33,7 +47,7 @@ Configure the `pom.xml` file of your Maven project to use DepClean as part of th
 <plugin>
   <groupId>se.kth.castor</groupId>
   <artifactId>depclean-maven-plugin</artifactId>
-  <version>2.0.6</version>
+  <version>2.1.0</version>
   <executions>
     <execution>
       <goals>
@@ -50,10 +64,10 @@ Or you can run DepClean directly from the command line.
 cd {PATH_TO_MAVEN_PROJECT}
 mvn compile
 mvn compiler:testCompile
-mvn se.kth.castor:depclean-maven-plugin:2.0.6:depclean
+mvn se.kth.castor:depclean-maven-plugin:2.1.0:depclean
 ```
 
-Let's see an example of running DepClean version 2.0.1 in the project [Apache Commons Numbers](https://github.com/apache/commons-numbers/tree/master/commons-numbers-examples/examples-jmh)!
+Let's see an example of running DepClean version 2.1.0 in the project [Apache Commons Numbers](https://github.com/apache/commons-numbers/tree/master/commons-numbers-examples/examples-jmh)!
 
 ![Demo](https://github.com/castor-software/depclean/blob/master/.img/demo.gif)
 
@@ -61,20 +75,18 @@ Let's see an example of running DepClean version 2.0.1 in the project [Apache Co
 
 The Maven plugin can be configured with the following additional parameters.
 
-
-| Name                       |     Type      | Description                                                                                                                                                                                                                                                                                                                                                                                                               | 
-|:---------------------------|:-------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
+| Name                       |     Type      | Description                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| :------------------------- | :-----------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<ignoreDependencies>`     | `Set<String>` | A regex expression matching dependencies to be ignored by DepClean during the analysis (i.e., considered as used). This is useful to bypass incomplete result caused by bytecode-level analysis. **For example:** `-DignoreDependencies="net.bytebuddy:byte-buddy:.*","com.google.guava.*"` ignores dependencies with `groupId:artifactId` equals to `net.bytebuddy:byte-buddy` and `groupId` equals to `com.google.guava`. |
-| `<ignoreScopes>`           | `Set<String>` | Add a list of scopes, to be ignored by DepClean during the analysis. Useful to not analyze dependencies with scopes that are not needed at runtime. **Valid scopes are:** `compile`, `provided`, `test`, `runtime`, `system`, `import`. An Empty string indicates no scopes (default).                                                                                                                                    |
-| `<ignoreTests>`            |   `boolean`   | If this is true, DepClean will not analyze the test classes in the project, and, therefore, the dependencies that are only used for testing will be considered unused. This parameter is useful to detect dependencies that have `compile` scope but are only used for testing. **Default value is:** `false`.                                                                                                            |
-| `<createPomDebloated>`     |   `boolean`   | If this is true, DepClean creates a debloated version of the pom without unused dependencies called `debloated-pom.xml`, in the root of the project. **Default value is:** `false`.                                                                                                                                                                                                                                       |
-| `<createResultJson>`       |   `boolean`   | If this is true, DepClean creates a JSON file of the dependency tree along with metadata of each dependency. The file is called `depclean-results.json`, and is located in the `target` directory of the project. **Default value is:** `false`.                                                                                                                                                                          |
-| `<createCallGraphCsv>`     |   `boolean`   | If this is true, DepClean creates a CSV file with the static call graph of the API members used in the project. The file is called `depclean-callgraph.csv`, and is located in the `target` directory of the project. **Default value is:** `false`.                                                                                                                                                                      |
-| `<failIfUnusedDirect>`     |   `boolean`   | If this is true, and DepClean reported any unused direct dependency in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                                                                                            |
-| `<failIfUnusedTransitive>` |   `boolean`   | If this is true, and DepClean reported any unused transitive dependency in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                                                                                        |
-| `<failIfUnusedInherited>`  |   `boolean`   | If this is true, and DepClean reported any unused inherited dependency in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                                                                                         |
-| `<skipDepClean>`           |   `boolean`   | Skip plugin execution completely. **Default value is:** `false`.                                                                                                                                                                                                                                                                                                                                                          |
-
+| `<ignoreScopes>`           | `Set<String>` | Add a list of scopes, to be ignored by DepClean during the analysis. Useful to not analyze dependencies with scopes that are not needed at runtime. **Valid scopes are:** `compile`, `provided`, `test`, `runtime`, `system`, `import`. An Empty string indicates no scopes (default).                                                                                                                                      |
+| `<ignoreTests>`            |   `boolean`   | If this is true, DepClean will not analyze the test classes in the project, and, therefore, the dependencies that are only used for testing will be considered unused. This parameter is useful to detect dependencies that have `compile` scope but are only used for testing. **Default value is:** `false`.                                                                                                              |
+| `<createPomDebloated>`     |   `boolean`   | If this is true, DepClean creates a debloated version of the pom without unused dependencies called `debloated-pom.xml`, in the root of the project. **Default value is:** `false`.                                                                                                                                                                                                                                         |
+| `<createResultJson>`       |   `boolean`   | If this is true, DepClean creates a JSON file of the dependency tree along with metadata of each dependency. The file is called `depclean-results.json`, and is located in the `target` directory of the project. **Default value is:** `false`.                                                                                                                                                                            |
+| `<createCallGraphCsv>`     |   `boolean`   | If this is true, DepClean creates a CSV file with the static call graph of the API members used in the project. The file is called `depclean-callgraph.csv`, and is located in the `target` directory of the project. **Default value is:** `false`.                                                                                                                                                                        |
+| `<failIfUnusedDirect>`     |   `boolean`   | If this is true, and DepClean reported any unused direct dependency in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                                                                                              |
+| `<failIfUnusedTransitive>` |   `boolean`   | If this is true, and DepClean reported any unused transitive dependency in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                                                                                          |
+| `<failIfUnusedInherited>`  |   `boolean`   | If this is true, and DepClean reported any unused inherited dependency in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                                                                                           |
+| `<skipDepClean>`           |   `boolean`   | Skip plugin execution completely. **Default value is:** `false`.                                                                                                                                                                                                                                                                                                                                                            |
 
 You can integrate DepClean in your CI/CD pipeline.
 For example, if you want to fail the build in the presence of unused direct dependencies, while ignoring all the dependency scopes except the
@@ -84,7 +96,7 @@ For example, if you want to fail the build in the presence of unused direct depe
 <plugin>
   <groupId>se.kth.castor</groupId>
   <artifactId>depclean-maven-plugin</artifactId>
-  <version>2.0.6</version>
+  <version>2.1.0</version>
   <executions>
     <execution>
       <goals>
@@ -102,7 +114,7 @@ For example, if you want to fail the build in the presence of unused direct depe
 Of course, it is also possible to execute DepClean with parameters directly from the command line. The previous example can be executed directly as follows:
 
 ```bash
-mvn se.kth.castor:depclean-maven-plugin:2.0.6:depclean -DfailIfUnusedDirect=true -DignoreScopes=provided,test,runtime,system,import
+mvn se.kth.castor:depclean-maven-plugin:2.1.0:depclean -DfailIfUnusedDirect=true -DignoreScopes=provided,test,runtime,system,import
 ```
 
 ## How does DepClean works?
@@ -123,7 +135,7 @@ If all the tests pass, and the project builds correctly after these changes, the
 
 Prerequisites:
 
-- [Java OpenJDK 11](https://openjdk.java.net) or above
+- [Java OpenJDK 21](https://openjdk.java.net) or above
 - [Apache Maven](https://maven.apache.org/)
 
 In a terminal clone the repository and switch to the cloned folder:
@@ -132,6 +144,7 @@ In a terminal clone the repository and switch to the cloned folder:
 git clone https://github.com/castor-software/depclean.git
 cd depclean
 ```
+
 Then run the following Maven command to build the application and install the plugin locally:
 
 ```bash

--- a/depclean-core/pom.xml
+++ b/depclean-core/pom.xml
@@ -8,12 +8,12 @@
   <parent>
     <groupId>se.kth.castor</groupId>
     <artifactId>depclean-parent-pom</artifactId>
-    <version>2.0.6</version>
+    <version>2.1.0</version>
   </parent>
 
   <!-- Coordinates -->
   <artifactId>depclean-core</artifactId>
-  <version>2.0.6</version>
+  <version>2.1.0</version>
   <packaging>jar</packaging>
   <description>Core library of DepClean</description>
   <name>depclean-core</name>

--- a/depclean-core/pom.xml
+++ b/depclean-core/pom.xml
@@ -76,8 +76,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>21</source>
+          <target>21</target>
         </configuration>
       </plugin>
     </plugins>

--- a/depclean-core/src/main/java/se/kth/depclean/core/AbstractDebloater.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/AbstractDebloater.java
@@ -26,8 +26,7 @@ public abstract class AbstractDebloater<T> {
     setDependencies(
         analysis.getUsedDependencies().stream()
             .map(this::toProviderDependency)
-            .collect(Collectors.toList())
-    );
+            .collect(Collectors.toList()));
     logDependencies();
     postProcessDependencies();
     writeFile();
@@ -42,8 +41,10 @@ public abstract class AbstractDebloater<T> {
   protected abstract void logDependencies();
 
   /**
-   * In order to keep the version as variable (property) for dependencies that were declared as such,
-   * post-process dependencies to replace interpolated version with the initial one.
+   * In order to keep the version as variable (property) for dependencies that
+   * were declared as such,
+   * post-process dependencies to replace interpolated version with the initial
+   * one.
    */
   protected abstract void postProcessDependencies();
 
@@ -53,22 +54,19 @@ public abstract class AbstractDebloater<T> {
       log.info("Adding {} used transitive {} as direct {}.",
           nbUsedTransitiveDeps,
           getDependencyWording(nbUsedTransitiveDeps),
-          getDependencyWording(nbUsedTransitiveDeps)
-      );
+          getDependencyWording(nbUsedTransitiveDeps));
     }
     if (analysis.hasUnusedDirectDependencies()) {
       final int nbUnusedDirectDeps = analysis.getUnusedDirectDependencies().size();
       log.info("Removing {} unused direct {}.",
           nbUnusedDirectDeps,
-          getDependencyWording(nbUnusedDirectDeps)
-      );
+          getDependencyWording(nbUnusedDirectDeps));
     }
     if (analysis.hasUnusedTransitiveDependencies()) {
       final int nbUnusedTransitiveDeps = analysis.getUnusedTransitiveDependencies().size();
       log.info("Excluding {} unused transitive {} one-by-one.",
           nbUnusedTransitiveDeps,
-          getDependencyWording(nbUnusedTransitiveDeps)
-      );
+          getDependencyWording(nbUnusedTransitiveDeps));
     }
   }
 

--- a/depclean-core/src/main/java/se/kth/depclean/core/DepCleanManager.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/DepCleanManager.java
@@ -114,18 +114,19 @@ public class DepCleanManager {
 
   @SneakyThrows
   private void extractClassesFromDependencies() {
-    File dependencyDirectory = dependencyManager.getBuildDirectory().resolve(DIRECTORY_TO_EXTRACT_DEPENDENCIES).toFile();
+    File dependencyDirectory = dependencyManager.getBuildDirectory().resolve(DIRECTORY_TO_EXTRACT_DEPENDENCIES)
+        .toFile();
     FileUtils.deleteDirectory(dependencyDirectory);
     dependencyManager.dependencyGraph().allDependencies()
         .forEach(jarFile -> copyDependencies(jarFile, dependencyDirectory));
 
-    // Workaround for dependencies that are in located in a project's libs directory.
+    // Workaround for dependencies that are in located in a project's libs
+    // directory.
     if (dependencyManager.getBuildDirectory().resolve("libs").toFile().exists()) {
       try {
         FileUtils.copyDirectory(
             dependencyManager.getBuildDirectory().resolve("libs").toFile(),
-            dependencyDirectory
-        );
+            dependencyDirectory);
       } catch (IOException | NullPointerException e) {
         getLog().error("Error copying directory libs to" + dependencyDirectory.getAbsolutePath());
       }
@@ -162,7 +163,8 @@ public class DepCleanManager {
     if (createCallGraphCsv) {
       printString("Creating " + csvFile.getName() + ", please wait...");
       try {
-        FileUtils.write(csvFile, "OriginClass,TargetClass,OriginDependency,TargetDependency\n", Charset.defaultCharset());
+        FileUtils.write(csvFile, "OriginClass,TargetClass,OriginDependency,TargetDependency\n",
+            Charset.defaultCharset());
       } catch (IOException e) {
         getLog().error("Error writing the CSV header.");
       }
@@ -171,8 +173,7 @@ public class DepCleanManager {
         treeFile,
         analysis,
         csvFile,
-        createCallGraphCsv
-    );
+        createCallGraphCsv);
 
     try {
       FileUtils.write(jsonFile, treeAsJson, Charset.defaultCharset());
@@ -201,8 +202,8 @@ public class DepCleanManager {
 
     // Consider as used all the classes located in the imports of the source code
     Set<ClassName> usedClassesFromSource = dependencyManager.collectUsedClassesFromSource(
-            dependencyManager.getSourceDirectory(),
-            dependencyManager.getTestDirectory())
+        dependencyManager.getSourceDirectory(),
+        dependencyManager.getTestDirectory())
         .stream()
         .map(ClassName::new)
         .collect(Collectors.toSet());
@@ -217,35 +218,29 @@ public class DepCleanManager {
         dependencyManager.getSourceDirectory(),
         dependencyManager.getTestDirectory(),
         dependencyManager.getDependenciesDirectory(),
-        ignoreScopes.stream().map(Scope::new).collect(Collectors.toSet()),
-        toDependency(dependencyManager.dependencyGraph().allDependencies(), ignoreDependencies),
-        allUsedClasses
-    );
+        ignoreScopes.stream()
+            .map(scope -> new Scope(scope))
+            .collect(Collectors.toSet()),
+        ignoreDependencies.stream()
+            .map(pattern -> toDependency(dependencyManager.dependencyGraph().allDependencies(), pattern))
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet()),
+        allUsedClasses);
   }
 
   /**
-   * Returns a set of {@code DependencyCoordinate}s that match given string representations.
+   * Returns a set of {@code DependencyCoordinate}s that match given string
+   * representations.
    *
    * @param allDependencies    all known dependencies
    * @param dependencyPatterns string representation of dependencies to match
    * @return a set of {@code Dependency} that match given string representations
    */
-  private Set<Dependency> toDependency(Set<Dependency> allDependencies, Set<String> dependencyPatterns) {
-    System.out.println("allDependencies: ");
-    allDependencies.forEach(System.out::println);
-    System.out.println("dependencyPatterns: ");
-    dependencyPatterns.forEach(System.out::println);
-
-    return dependencyPatterns.stream()
-            .flatMap(pattern -> findDependencies(allDependencies, pattern).stream())
-            .collect(Collectors.toSet());
-  }
-
-  private Set<Dependency> findDependencies(Set<Dependency> allDependencies, String patternString) {
+  private Set<Dependency> toDependency(Set<Dependency> allDependencies, String patternString) {
     Pattern pattern = Pattern.compile(patternString, Pattern.CASE_INSENSITIVE);
     return allDependencies.stream()
-            .filter(dep -> pattern.matcher(dep.toString()).matches())
-            .collect(Collectors.toSet());
+        .filter(dep -> pattern.matcher(dep.toString()).matches())
+        .collect(Collectors.toSet());
   }
 
   private String getTime(long millis) {
@@ -255,7 +250,7 @@ public class DepCleanManager {
   }
 
   private void printString(final String string) {
-    System.out.println(string); //NOSONAR avoid a warning of non-used logger
+    System.out.println(string); // NOSONAR avoid a warning of non-used logger
   }
 
   private LogWrapper getLog() {

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/ClassFileVisitorUtils.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/ClassFileVisitorUtils.java
@@ -34,12 +34,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.codehaus.plexus.util.DirectoryScanner;
 
 /**
- * Utility to visit classes in a library given either as a jar file or an exploded directory.
+ * Utility to visit classes in a library given either as a jar file or an
+ * exploded directory.
  */
 @Slf4j
 public final class ClassFileVisitorUtils {
 
-  private static final String[] CLASS_INCLUDES = {"**/*.class"};
+  private static final String[] CLASS_INCLUDES = { "**/*.class" };
   public static final String CLASS = ".class";
 
   /**
@@ -86,7 +87,7 @@ public final class ClassFileVisitorUtils {
   private static void acceptJar(URL url, ClassFileVisitor visitor) {
     try (JarInputStream in = new JarInputStream(url.openStream())) {
       JarEntry entry;
-      while ((entry = in.getNextJarEntry()) != null) { //NOSONAR
+      while ((entry = in.getNextJarEntry()) != null) { // NOSONAR
         String name = entry.getName();
         // ignore files like package-info.class and module-info.class
         if (name.endsWith(CLASS) && name.indexOf('-') == -1) {

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/ProjectDependencyAnalysisBuilder.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/ProjectDependencyAnalysisBuilder.java
@@ -17,7 +17,8 @@ import se.kth.depclean.core.model.ProjectContext;
 import se.kth.depclean.core.model.Scope;
 
 /**
- * Builds the analysis given the declared dependencies and the one actually used.
+ * Builds the analysis given the declared dependencies and the one actually
+ * used.
  */
 @Slf4j
 public class ProjectDependencyAnalysisBuilder {
@@ -51,8 +52,10 @@ public class ProjectDependencyAnalysisBuilder {
     // unused dependencies
     final Set<Dependency> unusedDirectDependencies = getUnusedDirectDependencies(usedDirectDependencies);
     final Set<Dependency> unusedTransitiveDependencies = getUnusedTransitiveDependencies(usedTransitiveDependencies);
-    final Set<Dependency> unusedInheritedDirectDependencies = getUnusedInheritedDirectDependencies(usedInheritedDirectDependencies);
-    final Set<Dependency> unusedInheritedTransitiveDependencies = getUnusedInheritedTransitiveDependencies(usedInheritedTransitiveDependencies);
+    final Set<Dependency> unusedInheritedDirectDependencies = getUnusedInheritedDirectDependencies(
+        usedInheritedDirectDependencies);
+    final Set<Dependency> unusedInheritedTransitiveDependencies = getUnusedInheritedTransitiveDependencies(
+        usedInheritedTransitiveDependencies);
     // classes in each dependency
     final Map<Dependency, DependencyTypes> dependencyClassesMap = buildDependencyClassesMap();
     // ignore dependencies
@@ -64,9 +67,12 @@ public class ProjectDependencyAnalysisBuilder {
     });
     // ignore scopes
     ignoreDependencyWithIgnoredScope(usedDirectDependencies, unusedDirectDependencies, context.getIgnoredScopes());
-    ignoreDependencyWithIgnoredScope(usedTransitiveDependencies, unusedTransitiveDependencies, context.getIgnoredScopes());
-    ignoreDependencyWithIgnoredScope(usedInheritedDirectDependencies, unusedInheritedDirectDependencies, context.getIgnoredScopes());
-    ignoreDependencyWithIgnoredScope(usedInheritedTransitiveDependencies, unusedInheritedTransitiveDependencies, context.getIgnoredScopes());
+    ignoreDependencyWithIgnoredScope(usedTransitiveDependencies, unusedTransitiveDependencies,
+        context.getIgnoredScopes());
+    ignoreDependencyWithIgnoredScope(usedInheritedDirectDependencies, unusedInheritedDirectDependencies,
+        context.getIgnoredScopes());
+    ignoreDependencyWithIgnoredScope(usedInheritedTransitiveDependencies, unusedInheritedTransitiveDependencies,
+        context.getIgnoredScopes());
 
     return new ProjectDependencyAnalysis(
         usedDirectDependencies,
@@ -79,8 +85,7 @@ public class ProjectDependencyAnalysisBuilder {
         unusedInheritedTransitiveDependencies,
         context.getIgnoredDependencies(),
         dependencyClassesMap,
-        context.getDependencyGraph()
-    );
+        context.getDependencyGraph());
   }
 
   private Map<Dependency, DependencyTypes> buildDependencyClassesMap() {
@@ -90,9 +95,13 @@ public class ProjectDependencyAnalysisBuilder {
       final Set<ClassName> allClasses = context.getClassesForDependency(dependency);
       final Set<ClassName> usedClasses = newHashSet(allClasses);
       usedClasses.retainAll(actualUsedClasses.getRegisteredClasses());
-      output.put(dependency, new DependencyTypes(allClasses, usedClasses));
+      output.put(dependency, buildDependencyTypes(allClasses, usedClasses));
     }
     return output;
+  }
+
+  private DependencyTypes buildDependencyTypes(Set<ClassName> allTypes, Set<ClassName> usedTypes) {
+    return new DependencyTypes(allTypes, usedTypes);
   }
 
   private Set<Dependency> getUsedInheritedDirectDependencies() {
@@ -136,7 +145,8 @@ public class ProjectDependencyAnalysisBuilder {
   }
 
   private Set<Dependency> getUnusedInheritedTransitiveDependencies(Set<Dependency> usedInheritedDependencies) {
-    return getUnusedDependencies(context.getDependencyGraph().inheritedTransitiveDependencies(), usedInheritedDependencies);
+    return getUnusedDependencies(context.getDependencyGraph().inheritedTransitiveDependencies(),
+        usedInheritedDependencies);
   }
 
   private Set<Dependency> getUnusedDependencies(Set<Dependency> baseDependencies, Set<Dependency> usedDependencies) {
@@ -146,15 +156,19 @@ public class ProjectDependencyAnalysisBuilder {
   }
 
   /**
-   * If the dependency to ignore is an unused dependency, then add it to the set of usedDependencyCoordinates and remove it from the set of
+   * If the dependency to ignore is an unused dependency, then add it to the set
+   * of usedDependencyCoordinates and remove it from the set of
    * unusedDependencyCoordinates.
    *
-   * @param usedDependencies   The set of used artifacts where the dependency will be added.
-   * @param unusedDependencies The set of unused artifacts where the dependency will be removed.
+   * @param usedDependencies   The set of used artifacts where the dependency will
+   *                           be added.
+   * @param unusedDependencies The set of unused artifacts where the dependency
+   *                           will be removed.
    * @param dependencyToIgnore The dependency to ignore.
    */
-  private void ignoreDependency(Set<Dependency> usedDependencies, Set<Dependency> unusedDependencies, Dependency dependencyToIgnore) {
-    for (Iterator<Dependency> i = unusedDependencies.iterator(); i.hasNext(); ) {
+  private void ignoreDependency(Set<Dependency> usedDependencies, Set<Dependency> unusedDependencies,
+      Dependency dependencyToIgnore) {
+    for (Iterator<Dependency> i = unusedDependencies.iterator(); i.hasNext();) {
       Dependency unusedDependency = i.next();
       if (dependencyToIgnore.equals(unusedDependency)) {
         usedDependencies.add(unusedDependency);
@@ -165,14 +179,18 @@ public class ProjectDependencyAnalysisBuilder {
   }
 
   /**
-   * If the scope of the unused dependency is to be ignored, then add the dependency to the set of used dependencies and remove it from the used set.
+   * If the scope of the unused dependency is to be ignored, then add the
+   * dependency to the set of used dependencies and remove it from the used set.
    *
-   * @param usedDependencies   The set of used artifacts where the dependency will be added.
-   * @param unusedDependencies The set of unused artifacts where the dependency will be removed.
+   * @param usedDependencies   The set of used artifacts where the dependency will
+   *                           be added.
+   * @param unusedDependencies The set of unused artifacts where the dependency
+   *                           will be removed.
    * @param ignoredScopes      The set of scopes to ignore.
    */
-  private void ignoreDependencyWithIgnoredScope(Set<Dependency> usedDependencies, Set<Dependency> unusedDependencies, Set<Scope> ignoredScopes) {
-    for (Iterator<Dependency> i = unusedDependencies.iterator(); i.hasNext(); ) {
+  private void ignoreDependencyWithIgnoredScope(Set<Dependency> usedDependencies, Set<Dependency> unusedDependencies,
+      Set<Scope> ignoredScopes) {
+    for (Iterator<Dependency> i = unusedDependencies.iterator(); i.hasNext();) {
       Dependency unusedDependency = i.next();
       List<String> scopesToIgnore = ignoredScopes.stream().map(Scope::getValue).collect(Collectors.toList());
       log.debug("Scopes to ignore: {}", scopesToIgnore);

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DependencyClassFileVisitor.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DependencyClassFileVisitor.java
@@ -59,32 +59,28 @@ public class DependencyClassFileVisitor implements ClassFileVisitor {
 
       /* visit class members */
       AnnotationVisitor annotationVisitor = new DefaultAnnotationVisitor(
-          resultCollector
-      );
+          resultCollector);
       SignatureVisitor signatureVisitor = new DefaultSignatureVisitor(
-          resultCollector
-      );
+          resultCollector);
       FieldVisitor fieldVisitor = new DefaultFieldVisitor(
           annotationVisitor,
-          resultCollector
-      );
+          resultCollector);
       MethodVisitor methodVisitor = new DefaultMethodVisitor(
           annotationVisitor,
           signatureVisitor,
-          resultCollector
-      );
+          resultCollector);
       DefaultClassVisitor defaultClassVisitor = new DefaultClassVisitor(
           signatureVisitor,
           annotationVisitor,
           fieldVisitor,
           methodVisitor,
-          resultCollector
-      );
+          resultCollector);
 
       reader.accept(defaultClassVisitor, 0);
 
       // inset edge in the graph based on the bytecode analysis
-      //System.out.println("Edge " + className + " -> " + resultCollector.getDependencies());
+      // System.out.println("Edge " + className + " -> " +
+      // resultCollector.getDependencies());
       DefaultCallGraph.addEdge(className, resultCollector.getDependencies());
 
     } catch (IndexOutOfBoundsException | IOException e) {

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
@@ -29,12 +29,14 @@ import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.traverse.DepthFirstIterator;
 
 /**
- * A directed graph G = (V, E) where V is a set of classes and E is a set of edges. Edges represent class member calls between the classes in V.
+ * A directed graph G = (V, E) where V is a set of classes and E is a set of
+ * edges. Edges represent class member calls between the classes in V.
  */
 @Slf4j
 public class DefaultCallGraph {
 
-  private static final AbstractBaseGraph<String, DefaultEdge> directedGraph = new DefaultDirectedGraph<>(DefaultEdge.class);
+  private static final AbstractBaseGraph<String, DefaultEdge> directedGraph = new DefaultDirectedGraph<>(
+      DefaultEdge.class);
   private static final Set<String> projectVertices = new HashSet<>();
   private static final Map<String, Set<String>> usagesPerClass = new HashMap<>();
 
@@ -59,7 +61,8 @@ public class DefaultCallGraph {
   }
 
   /**
-   * Traverses the call graph to obtain a set of all the reachable classes from a set of classes. Classes are vertices in the graph.
+   * Traverses the call graph to obtain a set of all the reachable classes from a
+   * set of classes. Classes are vertices in the graph.
    *
    * @param projectClasses The classes in the Maven project.
    * @return All the referenced classes.
@@ -90,7 +93,7 @@ public class DefaultCallGraph {
   }
 
   private static void addReferencedClassMember(String clazz, String referencedClassMember) {
-    //System.out.println("\t" + clazz + " -> " + referencedClassMember);
+    // System.out.println("\t" + clazz + " -> " + referencedClassMember);
     Set<String> s = usagesPerClass.computeIfAbsent(clazz, k -> new HashSet<>());
     s.add(referencedClassMember);
   }

--- a/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
@@ -38,11 +38,11 @@ public class Dependency {
   /**
    * Creates a dependency.
    *
-   * @param groupId groupId
+   * @param groupId      groupId
    * @param dependencyId dependencyId
-   * @param version version
-   * @param scope scope
-   * @param file the related dependency file (a jar in most cases)
+   * @param version      version
+   * @param scope        scope
+   * @param file         the related dependency file (a jar in most cases)
    */
   public Dependency(String groupId, String dependencyId, String version, String scope, File file) {
     this.groupId = groupId;
@@ -57,10 +57,10 @@ public class Dependency {
   /**
    * Creates a dependency for the current project.
    *
-   * @param groupId groupId
+   * @param groupId      groupId
    * @param dependencyId dependencyId
-   * @param version version
-   * @param file the related dependency file (a jar in most cases)
+   * @param version      version
+   * @param file         the related dependency file (a jar in most cases)
    */
   public Dependency(String groupId, String dependencyId, String version, File file) {
     this(groupId, dependencyId, version, null, file);
@@ -106,7 +106,8 @@ public class Dependency {
         log.error(e.getMessage(), e);
       }
     }
-    log.trace("Finding related classes for Dependency: " + groupId + ":" + dependencyId + ":" + version + ":" + scope + ":" + file);
+    log.trace("Finding related classes for Dependency: " + groupId + ":" + dependencyId + ":" + version + ":" + scope
+        + ":" + file);
     log.trace("Related classes: " + relatedClasses);
     return copyOf(relatedClasses);
   }

--- a/depclean-core/src/main/java/se/kth/depclean/core/model/ProjectContext.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/ProjectContext.java
@@ -16,7 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 import se.kth.depclean.core.analysis.graph.DependencyGraph;
 
 /**
- * Contains all information about the project's context. It doesn't have any reference to a given framework (Maven, Gradle, etc.).
+ * Contains all information about the project's context. It doesn't have any
+ * reference to a given framework (Maven, Gradle, etc.).
  */
 @Slf4j
 @ToString
@@ -56,8 +57,10 @@ public final class ProjectContext {
    * @param tesSourceFolder     where the project's test sources are located
    * @param dependenciesFolder  where the dependency classes are located
    * @param ignoredScopes       the scopes to ignore
-   * @param ignoredDependencies the dependencies to ignore (i.e. considered as 'used')
-   * @param extraClasses        some classes we want to tell the analyser to consider used
+   * @param ignoredDependencies the dependencies to ignore (i.e. considered as
+   *                            'used')
+   * @param extraClasses        some classes we want to tell the analyser to
+   *                            consider used
    */
   public ProjectContext(DependencyGraph dependencyGraph,
       Set<Path> outputFolders,
@@ -122,7 +125,6 @@ public final class ProjectContext {
           log.debug("Adding dependency {} with related classes: {}", dc, dc.getRelatedClasses());
           classesPerDependency.putAll(dc, dc.getRelatedClasses());
         });
-
 
   }
 

--- a/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
@@ -113,5 +113,4 @@ public final class JarUtils {
     }
   }
 
-
 }

--- a/depclean-gradle-plugin/build.gradle
+++ b/depclean-gradle-plugin/build.gradle
@@ -12,7 +12,7 @@ java {
 }
 
 group 'se.kth.castor'
-version '1.0-SNAPSHOT'
+version '2.1.0'
 
 repositories {
   mavenLocal()

--- a/depclean-gradle-plugin/build.gradle
+++ b/depclean-gradle-plugin/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(17))
+    languageVersion.set(JavaLanguageVersion.of(21))
   }
 }
 

--- a/depclean-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/depclean-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>se.kth.castor</groupId>
     <artifactId>depclean-parent-pom</artifactId>
-    <version>2.0.6</version>
+    <version>2.1.0</version>
   </parent>
 
   <!-- Coordinates -->
   <artifactId>depclean-maven-plugin</artifactId>
-  <version>2.0.6</version>
+  <version>2.1.0</version>
   <packaging>maven-plugin</packaging>
   <name>depclean-maven-plugin</name>
 
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>se.kth.castor</groupId>
       <artifactId>depclean-core</artifactId>
-      <version>2.0.6</version>
+      <version>2.1.0</version>
     </dependency>
     <!--Maven tools for plugin construction-->
     <dependency>

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
   <name>depclean-maven-plugin</name>
 
   <properties>
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     <checkstyle.config.location>../checkstyle.xml</checkstyle.config.location>
     <linkXRef>false</linkXRef>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <!-- Coordinates -->
   <groupId>se.kth.castor</groupId>
   <artifactId>depclean-parent-pom</artifactId>
-  <version>2.0.6</version>
+  <version>2.1.0</version>
   <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- plugins -->
-    <compiler.release>11</compiler.release>
-    <javadoc.source>11</javadoc.source>
+    <compiler.release>21</compiler.release>
+    <javadoc.source>21</javadoc.source>
     <javadoc.plugin.version>3.2.0</javadoc.plugin.version>
     <jacoco.plugin.version>0.8.13</jacoco.plugin.version>
     <coveralls.plugin.version>4.3.0</coveralls.plugin.version>
@@ -173,7 +173,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler.plugin.version}</version>
         <configuration>
-          <release>11</release>
+          <release>21</release>
         </configuration>
       </plugin>
       <!-- Maven site -->
@@ -234,7 +234,7 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <version>3.14.0</version>
             <configuration>
-              <release>11</release>
+              <release>21</release>
             </configuration>
           </plugin>
           <!-- Maven source plugin -->


### PR DESCRIPTION
This PR upgrades DepClean to support Java 21 (https://github.com/ASSERT-KTH/depclean/issues/272).
- Update Java version from 17 to 21 in all modules
- Update GitHub Actions workflows to use Java 21
- Update setup-java action to v4 and use Temurin distribution
- Update SonarCloud Java version settings. 
 
The project has been tested and builds successfully with Java 21.