### PR TITLE
remove void EqualsAndHashCode annotation

### DIFF
--- a/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
@@ -11,7 +11,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -23,7 +22,6 @@ import se.kth.depclean.core.analysis.DefaultClassAnalyzer;
  */
 @Slf4j
 @Getter
-@EqualsAndHashCode(exclude = "file")
 public class Dependency {
 
   private final String groupId;


### PR DESCRIPTION
Glancing over the git history of the class `Dependency`, `equals` and `hashcode` implementations were added months after `@EqualsAndHashCode` was added. Lombok won't generate those methods since custom implementations exist in this case, it means we can delete the Lombok annotation.