### PR TITLE
refactor: remove Lombok from the codebase

### DIFF
--- a/depclean-core/src/main/java/se/kth/depclean/core/AbstractDebloater.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/AbstractDebloater.java
@@ -3,17 +3,21 @@ package se.kth.depclean.core;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.kth.depclean.core.analysis.model.DebloatedDependency;
 import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
 
 /** Analyses the analysis result and writes the debloated config file. */
-@Slf4j
-@AllArgsConstructor
 public abstract class AbstractDebloater<T> {
 
+  private static final Logger log = LoggerFactory.getLogger(AbstractDebloater.class);
+
   protected final ProjectDependencyAnalysis analysis;
+
+  public AbstractDebloater(ProjectDependencyAnalysis analysis) {
+    this.analysis = analysis;
+  }
 
   /** Writes the debloated config file down. */
   public void write() throws IOException {

--- a/depclean-core/src/main/java/se/kth/depclean/core/DepCleanManager.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/DepCleanManager.java
@@ -8,9 +8,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.jspecify.annotations.Nullable;
 import se.kth.depclean.core.analysis.AnalysisFailureException;
@@ -25,8 +22,6 @@ import se.kth.depclean.core.wrapper.DependencyManagerWrapper;
 import se.kth.depclean.core.wrapper.LogWrapper;
 
 /** Runs the depclean process, regardless of a specific dependency manager. */
-@AllArgsConstructor
-@Slf4j
 public class DepCleanManager {
 
   private static final String SEPARATOR = "-------------------------------------------------------";
@@ -45,10 +40,37 @@ public class DepCleanManager {
   private final boolean createResultJson;
   private final boolean createCallGraphCsv;
 
+  /** Creates the DepClean manager. */
+  public DepCleanManager(
+      DependencyManagerWrapper dependencyManager,
+      boolean skipDepClean,
+      boolean ignoreTests,
+      Set<String> ignoreScopes,
+      Set<String> ignoreDependencies,
+      boolean failIfUnusedDirect,
+      boolean failIfUnusedTransitive,
+      boolean failIfUnusedInheritedDirect,
+      boolean failIfUnusedInheritedTransitive,
+      boolean createPomDebloated,
+      boolean createResultJson,
+      boolean createCallGraphCsv) {
+    this.dependencyManager = dependencyManager;
+    this.skipDepClean = skipDepClean;
+    this.ignoreTests = ignoreTests;
+    this.ignoreScopes = ignoreScopes;
+    this.ignoreDependencies = ignoreDependencies;
+    this.failIfUnusedDirect = failIfUnusedDirect;
+    this.failIfUnusedTransitive = failIfUnusedTransitive;
+    this.failIfUnusedInheritedDirect = failIfUnusedInheritedDirect;
+    this.failIfUnusedInheritedTransitive = failIfUnusedInheritedTransitive;
+    this.createPomDebloated = createPomDebloated;
+    this.createResultJson = createResultJson;
+    this.createCallGraphCsv = createCallGraphCsv;
+  }
+
   /** Execute the depClean manager. */
-  @SneakyThrows
   @Nullable
-  public ProjectDependencyAnalysis execute() throws AnalysisFailureException {
+  public ProjectDependencyAnalysis execute() throws AnalysisFailureException, IOException {
     final long startTime = System.currentTimeMillis();
 
     if (skipDepClean) {
@@ -111,8 +133,7 @@ public class DepCleanManager {
     return analysis;
   }
 
-  @SneakyThrows
-  private void extractClassesFromDependencies() {
+  private void extractClassesFromDependencies() throws IOException {
     File dependencyDirectory =
         dependencyManager.getBuildDirectory().resolve(DIRECTORY_TO_EXTRACT_DEPENDENCIES).toFile();
     FileUtils.deleteDirectory(dependencyDirectory);
@@ -145,9 +166,12 @@ public class DepCleanManager {
     }
   }
 
-  @SneakyThrows
   private void copyDependencies(File jarFile, File destFolder) {
-    FileUtils.copyFileToDirectory(jarFile, destFolder);
+    try {
+      FileUtils.copyFileToDirectory(jarFile, destFolder);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private void createResultJson(ProjectDependencyAnalysis analysis) {

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/ActualUsedClasses.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/ActualUsedClasses.java
@@ -2,7 +2,8 @@ package se.kth.depclean.core.analysis;
 
 import java.util.HashSet;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.kth.depclean.core.model.ClassName;
 import se.kth.depclean.core.model.ProjectContext;
 
@@ -10,8 +11,9 @@ import se.kth.depclean.core.model.ProjectContext;
  * Contains the actual classes used in the project (i.e. in classes, processors, configurations,
  * etc.)
  */
-@Slf4j
 public class ActualUsedClasses {
+
+  private static final Logger log = LoggerFactory.getLogger(ActualUsedClasses.class);
 
   private final ProjectContext context;
   private final Set<ClassName> classes = new HashSet<>();

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/ClassFileVisitorUtils.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/ClassFileVisitorUtils.java
@@ -30,12 +30,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
-import lombok.extern.slf4j.Slf4j;
 import org.codehaus.plexus.util.DirectoryScanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Utility to visit classes in a library given either as a jar file or an exploded directory. */
-@Slf4j
 public final class ClassFileVisitorUtils {
+
+  private static final Logger log = LoggerFactory.getLogger(ClassFileVisitorUtils.class);
 
   private static final String[] CLASS_INCLUDES = {"**/*.class"};
   public static final String CLASS = ".class";

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/DefaultClassAnalyzer.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/DefaultClassAnalyzer.java
@@ -22,11 +22,13 @@ package se.kth.depclean.core.analysis;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** The default class analyzer. */
-@Slf4j
 public class DefaultClassAnalyzer implements ClassAnalyzer {
+
+  private static final Logger log = LoggerFactory.getLogger(DefaultClassAnalyzer.class);
 
   /**
    * Analyze the class members.

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/DefaultProjectDependencyAnalyzer.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/DefaultProjectDependencyAnalyzer.java
@@ -22,8 +22,8 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.kth.depclean.core.analysis.asm.AsmDependencyAnalyzer;
 import se.kth.depclean.core.analysis.graph.DefaultCallGraph;
 import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
@@ -31,8 +31,10 @@ import se.kth.depclean.core.model.ClassName;
 import se.kth.depclean.core.model.ProjectContext;
 
 /** This is principal class that perform the dependency analysis in a Maven project. */
-@Slf4j
 public class DefaultProjectDependencyAnalyzer {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(DefaultProjectDependencyAnalyzer.class);
 
   private final DependencyAnalyzer dependencyAnalyzer = new AsmDependencyAnalyzer();
 
@@ -77,17 +79,23 @@ public class DefaultProjectDependencyAnalyzer {
     return new ProjectDependencyAnalysisBuilder(projectContext, actualUsedClasses).analyse();
   }
 
-  @SneakyThrows
   private Iterable<ClassName> getProjectDependencyClasses(Path outputFolder) {
     // Analyze src classes in the project
-    return collectDependencyClasses(outputFolder);
+    try {
+      return collectDependencyClasses(outputFolder);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
-  @SneakyThrows
   private Iterable<ClassName> getProjectTestDependencyClasses(Path testOutputFolder) {
     // Analyze test classes in the project
     log.trace("# getProjectTestDependencyClasses()");
-    return collectDependencyClasses(testOutputFolder);
+    try {
+      return collectDependencyClasses(testOutputFolder);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private Iterable<ClassName> collectDependencyClasses(Path path) throws IOException {

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/DependencyTypes.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/DependencyTypes.java
@@ -1,15 +1,11 @@
 package se.kth.depclean.core.analysis;
 
+import java.util.Objects;
 import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import org.jspecify.annotations.Nullable;
 import se.kth.depclean.core.model.ClassName;
 
 /** POJO containing the types in a dependency. */
-@Getter
-@EqualsAndHashCode
-@AllArgsConstructor
 public class DependencyTypes {
 
   /** An iterable to store the types. */
@@ -17,4 +13,34 @@ public class DependencyTypes {
 
   /** An iterable to store the used types. */
   private Set<ClassName> usedTypes;
+
+  public DependencyTypes(Set<ClassName> allTypes, Set<ClassName> usedTypes) {
+    this.allTypes = allTypes;
+    this.usedTypes = usedTypes;
+  }
+
+  public Set<ClassName> getAllTypes() {
+    return allTypes;
+  }
+
+  public Set<ClassName> getUsedTypes() {
+    return usedTypes;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DependencyTypes that = (DependencyTypes) o;
+    return Objects.equals(allTypes, that.allTypes) && Objects.equals(usedTypes, that.usedTypes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(allTypes, usedTypes);
+  }
 }

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/ProjectDependencyAnalysisBuilder.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/ProjectDependencyAnalysisBuilder.java
@@ -9,7 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
 import se.kth.depclean.core.model.ClassName;
 import se.kth.depclean.core.model.Dependency;
@@ -17,8 +18,10 @@ import se.kth.depclean.core.model.ProjectContext;
 import se.kth.depclean.core.model.Scope;
 
 /** Builds the analysis given the declared dependencies and the one actually used. */
-@Slf4j
 public class ProjectDependencyAnalysisBuilder {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(ProjectDependencyAnalysisBuilder.class);
 
   private final ProjectContext context;
   private final ActualUsedClasses actualUsedClasses;

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DependencyClassFileVisitor.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DependencyClassFileVisitor.java
@@ -22,12 +22,13 @@ package se.kth.depclean.core.analysis.asm;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.signature.SignatureVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.kth.depclean.core.analysis.ClassFileVisitor;
 import se.kth.depclean.core.analysis.graph.DefaultCallGraph;
 
@@ -37,8 +38,9 @@ import se.kth.depclean.core.analysis.graph.DefaultCallGraph;
  *
  * @see #getDependencies()
  */
-@Slf4j
 public class DependencyClassFileVisitor implements ClassFileVisitor {
+
+  private static final Logger log = LoggerFactory.getLogger(DependencyClassFileVisitor.class);
 
   private final ResultCollector resultCollector = new ResultCollector();
 

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
@@ -22,18 +22,20 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
 import org.jgrapht.graph.AbstractBaseGraph;
 import org.jgrapht.graph.DefaultDirectedGraph;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.traverse.DepthFirstIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A directed graph G = (V, E) where V is a set of classes and E is a set of edges. Edges represent
  * class member calls between the classes in V.
  */
-@Slf4j
 public class DefaultCallGraph {
+
+  private static final Logger log = LoggerFactory.getLogger(DefaultCallGraph.class);
 
   private static final AbstractBaseGraph<String, DefaultEdge> directedGraph =
       new DefaultDirectedGraph<>(DefaultEdge.class);

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/DebloatedDependency.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/DebloatedDependency.java
@@ -1,11 +1,9 @@
 package se.kth.depclean.core.analysis.model;
 
 import java.util.Set;
-import lombok.Getter;
 import se.kth.depclean.core.model.Dependency;
 
 /** A debloated dependency. */
-@Getter
 public class DebloatedDependency extends Dependency {
 
   private final Set<Dependency> exclusions;
@@ -13,5 +11,9 @@ public class DebloatedDependency extends Dependency {
   public DebloatedDependency(Dependency dependency, Set<Dependency> exclusions) {
     super(dependency);
     this.exclusions = exclusions;
+  }
+
+  public Set<Dependency> getExclusions() {
+    return exclusions;
   }
 }

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/DependencyAnalysisInfo.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/DependencyAnalysisInfo.java
@@ -1,20 +1,80 @@
 package se.kth.depclean.core.analysis.model;
 
+import java.util.Objects;
 import java.util.TreeSet;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import org.jspecify.annotations.Nullable;
 
 /** The result of a dependency analysis. */
-@Getter
-@ToString
-@EqualsAndHashCode
-@AllArgsConstructor
 public class DependencyAnalysisInfo {
   private final String status;
   private final String type;
   private final Long size;
   private final TreeSet<String> allTypes;
   private final TreeSet<String> usedTypes;
+
+  /** Creates a dependency analysis info. */
+  public DependencyAnalysisInfo(
+      String status, String type, Long size, TreeSet<String> allTypes, TreeSet<String> usedTypes) {
+    this.status = status;
+    this.type = type;
+    this.size = size;
+    this.allTypes = allTypes;
+    this.usedTypes = usedTypes;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public Long getSize() {
+    return size;
+  }
+
+  public TreeSet<String> getAllTypes() {
+    return allTypes;
+  }
+
+  public TreeSet<String> getUsedTypes() {
+    return usedTypes;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DependencyAnalysisInfo that = (DependencyAnalysisInfo) o;
+    return Objects.equals(status, that.status)
+        && Objects.equals(type, that.type)
+        && Objects.equals(size, that.size)
+        && Objects.equals(allTypes, that.allTypes)
+        && Objects.equals(usedTypes, that.usedTypes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(status, type, size, allTypes, usedTypes);
+  }
+
+  @Override
+  public String toString() {
+    return "DependencyAnalysisInfo(status="
+        + status
+        + ", type="
+        + type
+        + ", size="
+        + size
+        + ", allTypes="
+        + allTypes
+        + ", usedTypes="
+        + usedTypes
+        + ")";
+  }
 }

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/ProjectDependencyAnalysis.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/ProjectDependencyAnalysis.java
@@ -26,22 +26,17 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import se.kth.depclean.core.analysis.DependencyTypes;
 import se.kth.depclean.core.analysis.graph.DependencyGraph;
 import se.kth.depclean.core.model.ClassName;
 import se.kth.depclean.core.model.Dependency;
 
 /** Project dependencies analysis result. */
-@Getter
-@EqualsAndHashCode
-@Slf4j
 public class ProjectDependencyAnalysis {
 
   private static final String SEPARATOR = "-------------------------------------------------------";
@@ -83,6 +78,50 @@ public class ProjectDependencyAnalysis {
     this.ignoredDependencies = ImmutableSet.copyOf(ignoredDependencies);
     this.dependencyClassesMap = dependencyClassesMap;
     this.dependencyGraph = dependencyGraph;
+  }
+
+  public Set<Dependency> getUsedDirectDependencies() {
+    return usedDirectDependencies;
+  }
+
+  public Set<Dependency> getUsedTransitiveDependencies() {
+    return usedTransitiveDependencies;
+  }
+
+  public Set<Dependency> getUsedInheritedDirectDependencies() {
+    return usedInheritedDirectDependencies;
+  }
+
+  public Set<Dependency> getUsedInheritedTransitiveDependencies() {
+    return usedInheritedTransitiveDependencies;
+  }
+
+  public Set<Dependency> getUnusedDirectDependencies() {
+    return unusedDirectDependencies;
+  }
+
+  public Set<Dependency> getUnusedTransitiveDependencies() {
+    return unusedTransitiveDependencies;
+  }
+
+  public Set<Dependency> getUnusedInheritedDirectDependencies() {
+    return unusedInheritedDirectDependencies;
+  }
+
+  public Set<Dependency> getUnusedInheritedTransitiveDependencies() {
+    return unusedInheritedTransitiveDependencies;
+  }
+
+  public Set<Dependency> getIgnoredDependencies() {
+    return ignoredDependencies;
+  }
+
+  public Map<Dependency, DependencyTypes> getDependencyClassesMap() {
+    return dependencyClassesMap;
+  }
+
+  public DependencyGraph getDependencyGraph() {
+    return dependencyGraph;
   }
 
   public boolean hasUsedTransitiveDependencies() {
@@ -276,5 +315,46 @@ public class ProjectDependencyAnalysis {
             .filter(dep -> getUnusedTransitiveDependencies().contains(dep))
             .collect(Collectors.toSet());
     return new DebloatedDependency(dependency, ImmutableSet.copyOf(dependenciesToExclude));
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ProjectDependencyAnalysis that = (ProjectDependencyAnalysis) o;
+    return Objects.equals(usedDirectDependencies, that.usedDirectDependencies)
+        && Objects.equals(usedTransitiveDependencies, that.usedTransitiveDependencies)
+        && Objects.equals(usedInheritedDirectDependencies, that.usedInheritedDirectDependencies)
+        && Objects.equals(
+            usedInheritedTransitiveDependencies, that.usedInheritedTransitiveDependencies)
+        && Objects.equals(unusedDirectDependencies, that.unusedDirectDependencies)
+        && Objects.equals(unusedTransitiveDependencies, that.unusedTransitiveDependencies)
+        && Objects.equals(
+            unusedInheritedDirectDependencies, that.unusedInheritedDirectDependencies)
+        && Objects.equals(
+            unusedInheritedTransitiveDependencies, that.unusedInheritedTransitiveDependencies)
+        && Objects.equals(ignoredDependencies, that.ignoredDependencies)
+        && Objects.equals(dependencyClassesMap, that.dependencyClassesMap)
+        && Objects.equals(dependencyGraph, that.dependencyGraph);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        usedDirectDependencies,
+        usedTransitiveDependencies,
+        usedInheritedDirectDependencies,
+        usedInheritedTransitiveDependencies,
+        unusedDirectDependencies,
+        unusedTransitiveDependencies,
+        unusedInheritedDirectDependencies,
+        unusedInheritedTransitiveDependencies,
+        ignoredDependencies,
+        dependencyClassesMap,
+        dependencyGraph);
   }
 }

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/src/ImportsAnalyzer.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/src/ImportsAnalyzer.java
@@ -8,21 +8,34 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** All the classes imported in the source code of the project. */
-@Data
-@AllArgsConstructor
-@Slf4j
 public class ImportsAnalyzer {
+
+  private static final Logger log = LoggerFactory.getLogger(ImportsAnalyzer.class);
+
   private static final String[] SOURCE_FILE_EXTENSIONS = new String[] {"java"};
 
   /** A directory with Java source files. */
   private Path directoryPath;
+
+  public ImportsAnalyzer(Path directoryPath) {
+    this.directoryPath = directoryPath;
+  }
+
+  public Path getDirectoryPath() {
+    return directoryPath;
+  }
+
+  public void setDirectoryPath(Path directoryPath) {
+    this.directoryPath = directoryPath;
+  }
 
   /**
    * Collects the set of all imported classes in all the Java source files in a directory.
@@ -55,5 +68,27 @@ public class ImportsAnalyzer {
       imports.addAll(javaClass.getSource().getImports());
     }
     return imports;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ImportsAnalyzer that = (ImportsAnalyzer) o;
+    return Objects.equals(directoryPath, that.directoryPath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(directoryPath);
+  }
+
+  @Override
+  public String toString() {
+    return "ImportsAnalyzer(directoryPath=" + directoryPath + ")";
   }
 }

--- a/depclean-core/src/main/java/se/kth/depclean/core/model/ClassName.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/ClassName.java
@@ -1,12 +1,10 @@
 package se.kth.depclean.core.model;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import java.util.Objects;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /** Represents a class to be analysed. */
-@Getter
-@EqualsAndHashCode
 public class ClassName implements Comparable<ClassName> {
   private final String value;
 
@@ -21,6 +19,27 @@ public class ClassName implements Comparable<ClassName> {
       className = className.substring(0, className.length() - ".class".length());
     }
     this.value = className;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ClassName className = (ClassName) o;
+    return Objects.equals(value, className.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
   }
 
   @Override

--- a/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
@@ -10,18 +10,18 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.kth.depclean.core.analysis.ClassAnalyzer;
 import se.kth.depclean.core.analysis.DefaultClassAnalyzer;
 
 /** Identifies a dependency to analyse. */
-@Slf4j
-@Getter
 public class Dependency {
+
+  private static final Logger log = LoggerFactory.getLogger(Dependency.class);
 
   @NonNull private final String groupId;
   @NonNull private final String dependencyId;
@@ -80,6 +80,41 @@ public class Dependency {
         dependency.getVersion(),
         dependency.getScope(),
         dependency.getFile());
+  }
+
+  @NonNull
+  public String getGroupId() {
+    return groupId;
+  }
+
+  @NonNull
+  public String getDependencyId() {
+    return dependencyId;
+  }
+
+  @NonNull
+  public String getVersion() {
+    return version;
+  }
+
+  @Nullable
+  public String getScope() {
+    return scope;
+  }
+
+  @Nullable
+  public File getFile() {
+    return file;
+  }
+
+  @NonNull
+  public Long getSize() {
+    return size;
+  }
+
+  @NonNull
+  public Iterable<ClassName> getRelatedClasses() {
+    return relatedClasses;
   }
 
   @Override

--- a/depclean-core/src/main/java/se/kth/depclean/core/model/ProjectContext.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/ProjectContext.java
@@ -7,35 +7,34 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.kth.depclean.core.analysis.graph.DependencyGraph;
 
 /**
  * Contains all information about the project's context. It doesn't have any reference to a given
  * framework (Maven, Gradle, etc.).
  */
-@Slf4j
-@ToString
-@EqualsAndHashCode
 public final class ProjectContext {
+
+  private static final Logger log = LoggerFactory.getLogger(ProjectContext.class);
 
   private final Multimap<Dependency, ClassName> classesPerDependency = ArrayListMultimap.create();
   private final Multimap<ClassName, Dependency> dependenciesPerClass = ArrayListMultimap.create();
 
-  @Getter private final Set<Path> outputFolders;
-  @Getter private final Set<Path> testOutputFolders;
-  @Getter private final Path sourceFolder;
-  @Getter private final Path testFolder;
-  @Getter private final Path dependenciesFolder;
+  private final Set<Path> outputFolders;
+  private final Set<Path> testOutputFolders;
+  private final Path sourceFolder;
+  private final Path testFolder;
+  private final Path dependenciesFolder;
 
-  @Getter private final Set<Scope> ignoredScopes;
-  @Getter private final Set<Dependency> ignoredDependencies;
-  @Getter private final Set<ClassName> extraClasses;
-  @Getter private final DependencyGraph dependencyGraph;
+  private final Set<Scope> ignoredScopes;
+  private final Set<Dependency> ignoredDependencies;
+  private final Set<ClassName> extraClasses;
+  private final DependencyGraph dependencyGraph;
 
   /**
    * Creates a new project context.
@@ -78,6 +77,42 @@ public final class ProjectContext {
     populateDependenciesAndClassesMap(dependencyGraph.transitiveDependencies());
 
     Multimaps.invertFrom(classesPerDependency, dependenciesPerClass);
+  }
+
+  public Set<Path> getOutputFolders() {
+    return outputFolders;
+  }
+
+  public Set<Path> getTestOutputFolders() {
+    return testOutputFolders;
+  }
+
+  public Path getSourceFolder() {
+    return sourceFolder;
+  }
+
+  public Path getTestFolder() {
+    return testFolder;
+  }
+
+  public Path getDependenciesFolder() {
+    return dependenciesFolder;
+  }
+
+  public Set<Scope> getIgnoredScopes() {
+    return ignoredScopes;
+  }
+
+  public Set<Dependency> getIgnoredDependencies() {
+    return ignoredDependencies;
+  }
+
+  public Set<ClassName> getExtraClasses() {
+    return extraClasses;
+  }
+
+  public DependencyGraph getDependencyGraph() {
+    return dependencyGraph;
   }
 
   public Set<ClassName> getClassesForDependency(Dependency dependency) {
@@ -132,5 +167,70 @@ public final class ProjectContext {
       return true; // Don't exclude if scope is null
     }
     return ignoredScopes.stream().map(Scope::getValue).noneMatch(declaredScope::equalsIgnoreCase);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ProjectContext that = (ProjectContext) o;
+    return Objects.equals(classesPerDependency, that.classesPerDependency)
+        && Objects.equals(dependenciesPerClass, that.dependenciesPerClass)
+        && Objects.equals(outputFolders, that.outputFolders)
+        && Objects.equals(testOutputFolders, that.testOutputFolders)
+        && Objects.equals(sourceFolder, that.sourceFolder)
+        && Objects.equals(testFolder, that.testFolder)
+        && Objects.equals(dependenciesFolder, that.dependenciesFolder)
+        && Objects.equals(ignoredScopes, that.ignoredScopes)
+        && Objects.equals(ignoredDependencies, that.ignoredDependencies)
+        && Objects.equals(extraClasses, that.extraClasses)
+        && Objects.equals(dependencyGraph, that.dependencyGraph);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        classesPerDependency,
+        dependenciesPerClass,
+        outputFolders,
+        testOutputFolders,
+        sourceFolder,
+        testFolder,
+        dependenciesFolder,
+        ignoredScopes,
+        ignoredDependencies,
+        extraClasses,
+        dependencyGraph);
+  }
+
+  @Override
+  public String toString() {
+    return "ProjectContext(classesPerDependency="
+        + classesPerDependency
+        + ", dependenciesPerClass="
+        + dependenciesPerClass
+        + ", outputFolders="
+        + outputFolders
+        + ", testOutputFolders="
+        + testOutputFolders
+        + ", sourceFolder="
+        + sourceFolder
+        + ", testFolder="
+        + testFolder
+        + ", dependenciesFolder="
+        + dependenciesFolder
+        + ", ignoredScopes="
+        + ignoredScopes
+        + ", ignoredDependencies="
+        + ignoredDependencies
+        + ", extraClasses="
+        + extraClasses
+        + ", dependencyGraph="
+        + dependencyGraph
+        + ")";
   }
 }

--- a/depclean-core/src/main/java/se/kth/depclean/core/model/Scope.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/Scope.java
@@ -1,15 +1,39 @@
 package se.kth.depclean.core.model;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /** Represents a dependency scope. */
-@Getter
-@ToString
-@EqualsAndHashCode
-@AllArgsConstructor
 public class Scope {
   private final String value;
+
+  public Scope(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Scope scope = (Scope) o;
+    return Objects.equals(value, scope.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
+  }
+
+  @Override
+  public String toString() {
+    return "Scope(value=" + value + ")";
+  }
 }

--- a/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
@@ -26,12 +26,14 @@ import java.util.Enumeration;
 import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Utility class to handle JAR files. */
-@Slf4j
 public final class JarUtils {
+
+  private static final Logger log = LoggerFactory.getLogger(JarUtils.class);
 
   /** Size of the buffer to read/write data. */
   private static final int BUFFER_SIZE = 16384;

--- a/depclean-core/src/test/java/se/kth/depclean/core/DepCleanManagerEnd2EndTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/DepCleanManagerEnd2EndTest.java
@@ -5,11 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.SneakyThrows;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
@@ -48,7 +48,7 @@ class DepCleanManagerEnd2EndTest {
 
   @Test
   @SuppressWarnings("NullAway")
-  void shouldBeSkipped() throws AnalysisFailureException {
+  void shouldBeSkipped() throws AnalysisFailureException, IOException {
     final DepCleanManager depCleanManager = new DepCleanManagerBuilder().skipDepClean().build();
 
     depCleanManager.execute();
@@ -58,7 +58,7 @@ class DepCleanManagerEnd2EndTest {
 
   @Test
   @SuppressWarnings("NullAway")
-  void shouldBeSkippedBecauseOfType() throws AnalysisFailureException {
+  void shouldBeSkippedBecauseOfType() throws AnalysisFailureException, IOException {
     final DepCleanManager depCleanManager =
         new DepCleanManagerBuilder()
             .withDependencyManager(new FakeDependencyManagerWithMavenPomType())
@@ -71,7 +71,7 @@ class DepCleanManagerEnd2EndTest {
 
   @Test
   @SuppressWarnings("NullAway")
-  void shouldPassForEmptyProject() throws AnalysisFailureException {
+  void shouldPassForEmptyProject() throws AnalysisFailureException, IOException {
     final DepCleanManager depCleanManager =
         new DepCleanManagerBuilder()
             .withDependencyManager(EmptyProjectDependencyManager.class)
@@ -91,7 +91,7 @@ class DepCleanManagerEnd2EndTest {
 
   @Test
   @SuppressWarnings("NullAway")
-  void shouldReportAllDependencyUsed() throws AnalysisFailureException {
+  void shouldReportAllDependencyUsed() throws AnalysisFailureException, IOException {
     final DepCleanManager depCleanManager =
         new DepCleanManagerBuilder()
             .withDependencyManager(AllDependenciesUsedDependencyManager.class)
@@ -111,7 +111,7 @@ class DepCleanManagerEnd2EndTest {
 
   @Test
   @SuppressWarnings("NullAway")
-  void shouldReportNoDependencyUsed() throws AnalysisFailureException {
+  void shouldReportNoDependencyUsed() throws AnalysisFailureException, IOException {
     final DepCleanManager depCleanManager =
         new DepCleanManagerBuilder()
             .withDependencyManager(NoDependencyUsedDependencyManager.class)
@@ -131,7 +131,8 @@ class DepCleanManagerEnd2EndTest {
 
   @Test
   @SuppressWarnings("NullAway")
-  void shouldReportOnlyDirectAndInheritedDependenciesUsed() throws AnalysisFailureException {
+  void shouldReportOnlyDirectAndInheritedDependenciesUsed()
+      throws AnalysisFailureException, IOException {
     final DepCleanManager depCleanManager =
         new DepCleanManagerBuilder()
             .withDependencyManager(OnlyDirectAndInheritedUsedDependencyManager.class)
@@ -152,7 +153,7 @@ class DepCleanManagerEnd2EndTest {
 
   @Test
   @SuppressWarnings("NullAway")
-  void shouldReportOnlyDirectDependencyUsed() throws AnalysisFailureException {
+  void shouldReportOnlyDirectDependencyUsed() throws AnalysisFailureException, IOException {
     final DepCleanManager depCleanManager =
         new DepCleanManagerBuilder()
             .withDependencyManager(OnlyDirectUsedDependencyManager.class)
@@ -218,7 +219,7 @@ class DepCleanManagerEnd2EndTest {
 
   @Test
   @SuppressWarnings("NullAway")
-  void shouldIgnoreDependencies() throws AnalysisFailureException {
+  void shouldIgnoreDependencies() throws AnalysisFailureException, IOException {
     final DepCleanManager depCleanManager =
         new DepCleanManagerBuilder()
             .withDependencyManager(OnlyDirectAndInheritedUsedDependencyManager.class)
@@ -322,10 +323,13 @@ class DepCleanManagerEnd2EndTest {
       return this;
     }
 
-    @SneakyThrows
     public <T extends FakeDependencyManager> DepCleanManagerBuilder withDependencyManager(
         Class<T> clazz) {
-      this.dependencyManager = clazz.getDeclaredConstructor(Logger.class).newInstance(logger);
+      try {
+        this.dependencyManager = clazz.getDeclaredConstructor(Logger.class).newInstance(logger);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
       return this;
     }
 

--- a/depclean-core/src/test/java/se/kth/depclean/core/analysis/CollectorClassFileVisitorTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/analysis/CollectorClassFileVisitorTest.java
@@ -1,17 +1,18 @@
 package se.kth.depclean.core.analysis;
 
-import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-@Slf4j
 class CollectorClassFileVisitorTest {
+
+  private static final Logger log = LoggerFactory.getLogger(CollectorClassFileVisitorTest.class);
 
   private static final File classFile = new File("src/test/resources/analysisResources/test.class");
   private static final String className = "test";

--- a/depclean-core/src/test/java/se/kth/depclean/core/analysis/ProjectContextCreator.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/analysis/ProjectContextCreator.java
@@ -7,7 +7,6 @@ import java.io.File;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Set;
-import lombok.AllArgsConstructor;
 import se.kth.depclean.core.analysis.graph.DependencyGraph;
 import se.kth.depclean.core.model.ClassName;
 import se.kth.depclean.core.model.Dependency;
@@ -92,7 +91,6 @@ public interface ProjectContextCreator {
     return new Dependency("se.kth.depclean.core.analysis", name, "1.0.0", "test", jarFile);
   }
 
-  @AllArgsConstructor
   class TestDependencyGraph implements DependencyGraph {
 
     private final Dependency projectCoordinates;
@@ -100,6 +98,19 @@ public interface ProjectContextCreator {
     private final Set<Dependency> inheritedDirectDependencies;
     private final Set<Dependency> inheritedTransitiveDependencies;
     private final Set<Dependency> transitiveDependencies;
+
+    public TestDependencyGraph(
+        Dependency projectCoordinates,
+        Set<Dependency> directDependencies,
+        Set<Dependency> inheritedDirectDependencies,
+        Set<Dependency> inheritedTransitiveDependencies,
+        Set<Dependency> transitiveDependencies) {
+      this.projectCoordinates = projectCoordinates;
+      this.directDependencies = directDependencies;
+      this.inheritedDirectDependencies = inheritedDirectDependencies;
+      this.inheritedTransitiveDependencies = inheritedTransitiveDependencies;
+      this.transitiveDependencies = transitiveDependencies;
+    }
 
     @Override
     public Dependency projectCoordinates() {

--- a/depclean-core/src/test/java/se/kth/depclean/core/analysis/graph/DefaultCallGraphTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/analysis/graph/DefaultCallGraphTest.java
@@ -3,13 +3,11 @@ package se.kth.depclean.core.analysis.graph;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@Slf4j
 class DefaultCallGraphTest {
 
   @BeforeEach

--- a/depclean-core/src/test/java/se/kth/depclean/core/util/JarUtilsTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/util/JarUtilsTest.java
@@ -5,16 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Slf4j
 class JarUtilsTest {
+
+  private static final Logger log = LoggerFactory.getLogger(JarUtilsTest.class);
 
   // The directories used for testing
   static final File originalDir = new File("src/test/resources/JarUtilsResources");

--- a/depclean-gradle-plugin/build.gradle
+++ b/depclean-gradle-plugin/build.gradle
@@ -31,7 +31,6 @@ ext {
     depcleanVersion = '2.2.0-SNAPSHOT'
     errorProneCoreVersion = '2.50.0'
     jspecifyVersion = '1.0.1'
-    lombokVersion = '1.18.46'
     nullawayVersion = '0.14.0'
     slf4jVersion = '2.0.18'
     spockVersion = '2.4-groovy-4.0'
@@ -46,8 +45,6 @@ dependencies {
     implementation("org.slf4j:slf4j-reload4j:${slf4jVersion}")
     compileOnly("org.jspecify:jspecify:${jspecifyVersion}")
 
-    compileOnly("org.projectlombok:lombok:${lombokVersion}")
-    annotationProcessor("org.projectlombok:lombok:${lombokVersion}")
     implementation("com.github.spotbugs:spotbugs-annotations:${spotbugsAnnotationsVersion}")
 
     testImplementation("org.spockframework:spock-core:${spockVersion}")

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/DepCleanGradleAction.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/DepCleanGradleAction.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
@@ -64,7 +63,6 @@ public class DepCleanGradleAction implements Action<Project> {
   private Set<String> ignoreConfiguration = new HashSet<>();
   private Set<String> ignoreDependencies = new HashSet<>();
 
-  @SneakyThrows
   @Override
   public void execute(@NonNull Project project) {
 

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/analysis/DefaultGradleProjectDependencyAnalyzer.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/analysis/DefaultGradleProjectDependencyAnalyzer.java
@@ -14,13 +14,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.kth.depclean.core.analysis.ClassAnalyzer;
 import se.kth.depclean.core.analysis.DefaultClassAnalyzer;
 import se.kth.depclean.core.analysis.DependencyAnalyzer;
@@ -31,8 +31,10 @@ import se.kth.depclean.core.model.ClassName;
 import se.kth.depclean.utils.DependencyUtils;
 
 /** This is principal class that perform the dependency analysis in a Gradle project. */
-@Slf4j
 public class DefaultGradleProjectDependencyAnalyzer implements GradleProjectDependencyAnalyzer {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(DefaultGradleProjectDependencyAnalyzer.class);
 
   private final ClassAnalyzer classAnalyzer = new DefaultClassAnalyzer();
 
@@ -60,64 +62,67 @@ public class DefaultGradleProjectDependencyAnalyzer implements GradleProjectDepe
    *     unusedDeclaredArtifacts.
    * @see <code>ProjectDependencyAnalyzer#analyze(org.apache.invoke.project.MavenProject)</code>
    */
-  @SneakyThrows
   @Override
   public GradleProjectDependencyAnalysis analyze(final Project project) {
-    // Use the filtered resolvable configurations instead of all configurations
-    DependencyUtils utils = new DependencyUtils();
-    Set<Configuration> configurations = utils.getResolvableConfigurations(project);
+    try {
+      // Use the filtered resolvable configurations instead of all configurations
+      DependencyUtils utils = new DependencyUtils();
+      Set<Configuration> configurations = utils.getResolvableConfigurations(project);
 
-    // all resolved dependencies including transitive ones of the project.
-    Set<ResolvedDependency> allDependencies = utils.getAllDependencies(configurations);
+      // all resolved dependencies including transitive ones of the project.
+      Set<ResolvedDependency> allDependencies = utils.getAllDependencies(configurations);
 
-    // all resolved artifacts of this project
-    Set<ResolvedArtifact> allArtifacts = new HashSet<>();
-    for (ResolvedDependency dependency : allDependencies) {
-      allArtifacts.addAll(dependency.getModuleArtifacts());
+      // all resolved artifacts of this project
+      Set<ResolvedArtifact> allArtifacts = new HashSet<>();
+      for (ResolvedDependency dependency : allDependencies) {
+        allArtifacts.addAll(dependency.getModuleArtifacts());
+      }
+
+      // a map of [dependency] -> [classes]
+      artifactClassesMap = buildArtifactClassMap(allArtifacts);
+
+      // direct dependencies of the project
+      Set<ResolvedDependency> declaredDependencies = utils.getDeclaredDependencies(configurations);
+
+      // direct artifacts of the project
+      Set<ResolvedArtifact> declaredArtifacts = utils.getDeclaredArtifacts(declaredDependencies);
+
+      /* ******************** bytecode analysis ********************* */
+
+      // execute the analysis (note that the order of these operations matters!)
+      buildProjectDependencyClasses(project);
+      Set<String> projectClasses = new HashSet<>(DefaultCallGraph.getProjectVertices());
+      buildDependenciesDependencyClasses(project);
+
+      /* ******************** usage analysis ********************* */
+
+      // search for the dependencies used by the project
+      Set<ResolvedArtifact> usedArtifacts =
+          collectUsedArtifacts(
+              artifactClassesMap, DefaultCallGraph.referencedClassMembers(projectClasses));
+
+      /*
+       * ******************** results as statically used at the bytecode
+       * ***********************
+       */
+
+      // for the used dependencies, get the ones that are declared
+      Set<ResolvedArtifact> usedDeclaredArtifacts = new LinkedHashSet<>(declaredArtifacts);
+      usedDeclaredArtifacts.retainAll(usedArtifacts);
+
+      // for the used dependencies, remove the ones that are declared
+      Set<ResolvedArtifact> usedUndeclaredArtifacts = new LinkedHashSet<>(usedArtifacts);
+      usedUndeclaredArtifacts = removeAll(usedUndeclaredArtifacts, declaredArtifacts);
+
+      // for the declared dependencies, get the ones that are not used
+      Set<ResolvedArtifact> unusedDeclaredArtifacts = new LinkedHashSet<>(declaredArtifacts);
+      unusedDeclaredArtifacts = removeAll(unusedDeclaredArtifacts, usedArtifacts);
+
+      return new GradleProjectDependencyAnalysis(
+          usedDeclaredArtifacts, usedUndeclaredArtifacts, unusedDeclaredArtifacts);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
-
-    // a map of [dependency] -> [classes]
-    artifactClassesMap = buildArtifactClassMap(allArtifacts);
-
-    // direct dependencies of the project
-    Set<ResolvedDependency> declaredDependencies = utils.getDeclaredDependencies(configurations);
-
-    // direct artifacts of the project
-    Set<ResolvedArtifact> declaredArtifacts = utils.getDeclaredArtifacts(declaredDependencies);
-
-    /* ******************** bytecode analysis ********************* */
-
-    // execute the analysis (note that the order of these operations matters!)
-    buildProjectDependencyClasses(project);
-    Set<String> projectClasses = new HashSet<>(DefaultCallGraph.getProjectVertices());
-    buildDependenciesDependencyClasses(project);
-
-    /* ******************** usage analysis ********************* */
-
-    // search for the dependencies used by the project
-    Set<ResolvedArtifact> usedArtifacts =
-        collectUsedArtifacts(
-            artifactClassesMap, DefaultCallGraph.referencedClassMembers(projectClasses));
-
-    /*
-     * ******************** results as statically used at the bytecode
-     * ***********************
-     */
-
-    // for the used dependencies, get the ones that are declared
-    Set<ResolvedArtifact> usedDeclaredArtifacts = new LinkedHashSet<>(declaredArtifacts);
-    usedDeclaredArtifacts.retainAll(usedArtifacts);
-
-    // for the used dependencies, remove the ones that are declared
-    Set<ResolvedArtifact> usedUndeclaredArtifacts = new LinkedHashSet<>(usedArtifacts);
-    usedUndeclaredArtifacts = removeAll(usedUndeclaredArtifacts, declaredArtifacts);
-
-    // for the declared dependencies, get the ones that are not used
-    Set<ResolvedArtifact> unusedDeclaredArtifacts = new LinkedHashSet<>(declaredArtifacts);
-    unusedDeclaredArtifacts = removeAll(unusedDeclaredArtifacts, usedArtifacts);
-
-    return new GradleProjectDependencyAnalysis(
-        usedDeclaredArtifacts, usedUndeclaredArtifacts, unusedDeclaredArtifacts);
   }
 
   /**

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/DependencyUtils.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/DependencyUtils.java
@@ -4,13 +4,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import lombok.NonNull;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
+import org.jspecify.annotations.NonNull;
 
 public class DependencyUtils {
 

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/json/JsonResultWriter.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/json/JsonResultWriter.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ResolvedDependency;
@@ -24,7 +23,6 @@ import se.kth.depclean.core.model.ClassName;
  * file. This file represent the structure of the dependency tree enriched with metadata of the
  * usage or not of each dependency.
  */
-@Slf4j
 public class JsonResultWriter {
 
   private final Project project;

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
@@ -17,9 +17,8 @@
 
 package se.kth.depclean;
 
+import java.io.IOException;
 import java.util.Set;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -52,7 +51,6 @@ import se.kth.depclean.wrapper.MavenDependencyManager;
     requiresDependencyCollection = ResolutionScope.TEST,
     requiresDependencyResolution = ResolutionScope.TEST,
     threadSafe = true)
-@Slf4j
 public class DepCleanMojo extends AbstractMojo {
 
   /** The Maven project to analyze. */
@@ -147,9 +145,8 @@ public class DepCleanMojo extends AbstractMojo {
   @SuppressWarnings("NullAway") // Injected by Maven
   private DependencyGraphBuilder dependencyGraphBuilder;
 
-  @SneakyThrows
   @Override
-  public final void execute() {
+  public final void execute() throws MojoExecutionException {
     try {
       new DepCleanManager(
               new MavenDependencyManager(getLog(), project, session, dependencyGraphBuilder),
@@ -165,7 +162,7 @@ public class DepCleanMojo extends AbstractMojo {
               createResultJson,
               createCallGraphCsv)
           .execute();
-    } catch (AnalysisFailureException e) {
+    } catch (AnalysisFailureException | IOException e) {
       throw new MojoExecutionException(e.getMessage(), e);
     }
   }

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/graph/MavenDependencyGraph.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/graph/MavenDependencyGraph.java
@@ -12,18 +12,20 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.kth.depclean.core.analysis.graph.DependencyGraph;
 import se.kth.depclean.core.model.Dependency;
 
 /** A dependency graph for maven reactor. */
-@Slf4j
 public class MavenDependencyGraph implements DependencyGraph {
+
+  private static final Logger log = LoggerFactory.getLogger(MavenDependencyGraph.class);
 
   private final Set<Dependency> allDependencies;
   private final MavenProject project;

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/util/FileUtils.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/util/FileUtils.java
@@ -20,10 +20,8 @@ package se.kth.depclean.util;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import lombok.extern.slf4j.Slf4j;
 
 /** Utility class to handle files and directories. */
-@Slf4j
 public final class FileUtils {
 
   private FileUtils() {}

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenDebloater.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenDebloater.java
@@ -7,20 +7,22 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Locale;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Exclusion;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.kth.depclean.core.AbstractDebloater;
 import se.kth.depclean.core.analysis.model.DebloatedDependency;
 import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
 
 /** Writes a debloated pom is needed. */
-@Slf4j
 public class MavenDebloater extends AbstractDebloater<Dependency> {
+
+  private static final Logger log = LoggerFactory.getLogger(MavenDebloater.class);
 
   private final MavenProject project;
   private final Model model;

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenInvoker.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenInvoker.java
@@ -25,10 +25,8 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 
 /** Utility class to execute Maven tasks from the command line. */
-@Slf4j
 public final class MavenInvoker {
 
   private MavenInvoker() {}

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/util/json/NodeAdapter.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/util/json/NodeAdapter.java
@@ -9,19 +9,25 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
-import lombok.AllArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import se.kth.depclean.core.analysis.graph.DefaultCallGraph;
 import se.kth.depclean.core.analysis.model.DependencyAnalysisInfo;
 import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
 
 /** Custom Gson type adapter to write a JSON file with information of the dependencies. */
-@AllArgsConstructor
 public class NodeAdapter extends TypeAdapter<Node> {
 
   private final ProjectDependencyAnalysis analysis;
   private final File callGraphFile;
   private final boolean createCallGraphCsv;
+
+  /** Creates the adapter. */
+  public NodeAdapter(
+      ProjectDependencyAnalysis analysis, File callGraphFile, boolean createCallGraphCsv) {
+    this.analysis = analysis;
+    this.callGraphFile = callGraphFile;
+    this.createCallGraphCsv = createCallGraphCsv;
+  }
 
   @Override
   public void write(JsonWriter jsonWriter, Node node) throws IOException {

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/util/json/ParsedDependencies.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/util/json/ParsedDependencies.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import lombok.AllArgsConstructor;
 import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
 
 /**
@@ -21,13 +20,24 @@ import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
  * This file represent the structure of the dependency tree enriched with metadata of the usage or
  * not of each dependency.
  */
-@AllArgsConstructor
 public class ParsedDependencies {
 
   private final File treeFile;
   private final ProjectDependencyAnalysis analysis;
   private final File classUsageFile;
   private final boolean createCallgraphCsv;
+
+  /** Creates the parsed dependencies. */
+  public ParsedDependencies(
+      File treeFile,
+      ProjectDependencyAnalysis analysis,
+      File classUsageFile,
+      boolean createCallgraphCsv) {
+    this.treeFile = treeFile;
+    this.analysis = analysis;
+    this.classUsageFile = classUsageFile;
+    this.createCallgraphCsv = createCallgraphCsv;
+  }
 
   /**
    * Creates string with the JSON representation of the enriched dependency tree of the Maven

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
@@ -1,6 +1,7 @@
 package se.kth.depclean.wrapper;
 
 import com.google.common.collect.ImmutableSet;
+import fr.dutra.tools.maven.deptree.core.ParseException;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -13,8 +14,6 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import lombok.SneakyThrows;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
@@ -23,6 +22,7 @@ import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import se.kth.depclean.core.AbstractDebloater;
@@ -37,7 +37,6 @@ import se.kth.depclean.util.MavenInvoker;
 import se.kth.depclean.util.json.ParsedDependencies;
 
 /** Maven's implementation of the dependency manager wrapper. */
-@AllArgsConstructor
 public class MavenDependencyManager implements DependencyManagerWrapper {
 
   private static final String DIRECTORY_TO_COPY_DEPENDENCIES = "dependency";
@@ -47,6 +46,20 @@ public class MavenDependencyManager implements DependencyManagerWrapper {
   private final MavenSession session;
   private final DependencyGraphBuilder dependencyGraphBuilder;
   private final Model model;
+
+  /** Creates the manager with an already-built model. */
+  public MavenDependencyManager(
+      Log logger,
+      MavenProject project,
+      MavenSession session,
+      DependencyGraphBuilder dependencyGraphBuilder,
+      Model model) {
+    this.logger = logger;
+    this.project = project;
+    this.session = session;
+    this.dependencyGraphBuilder = dependencyGraphBuilder;
+    this.model = model;
+  }
 
   /**
    * Creates the manager.
@@ -99,13 +112,16 @@ public class MavenDependencyManager implements DependencyManagerWrapper {
   }
 
   @Override
-  @SneakyThrows
   public DependencyGraph dependencyGraph() {
     ProjectBuildingRequest buildingRequest =
         new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
     buildingRequest.setProject(project);
-    DependencyNode rootNode = dependencyGraphBuilder.buildDependencyGraph(buildingRequest, null);
-    return new MavenDependencyGraph(project, model, rootNode);
+    try {
+      DependencyNode rootNode = dependencyGraphBuilder.buildDependencyGraph(buildingRequest, null);
+      return new MavenDependencyGraph(project, model, rootNode);
+    } catch (DependencyGraphBuilderException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
@@ -216,14 +232,17 @@ public class MavenDependencyManager implements DependencyManagerWrapper {
         "mvn dependency:tree -DoutputFile=" + treeFile + " -Dverbose=true", null);
   }
 
-  @SneakyThrows
   @Override
   public String getTreeAsJson(
       File treeFile,
       ProjectDependencyAnalysis analysis,
       File classUsageFile,
       boolean createCallGraphCsv) {
-    return new ParsedDependencies(treeFile, analysis, classUsageFile, createCallGraphCsv)
-        .parseTreeToJson();
+    try {
+      return new ParsedDependencies(treeFile, analysis, classUsageFile, createCallGraphCsv)
+          .parseTreeToJson();
+    } catch (ParseException | IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
@@ -8,10 +8,11 @@ import com.soebes.itf.jupiter.maven.MavenExecutionResult;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.kth.depclean.util.OsUtils;
 
 /**
@@ -25,8 +26,9 @@ import se.kth.depclean.util.OsUtils;
  *     https://khmarbaise.github.io/maven-it-extension/itf-documentation/background/background.html#_assertions_in_maven_tests</a>
  */
 @MavenJupiterExtension
-@Slf4j
 public class DepCleanMojoIT {
+
+  private static final Logger log = LoggerFactory.getLogger(DepCleanMojoIT.class);
 
   @MavenTest
   void empty_project(MavenExecutionResult result) {

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/util/FileUtilsTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/util/FileUtilsTest.java
@@ -2,15 +2,17 @@ package se.kth.depclean.util;
 
 import java.io.File;
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Unit tests for {@link FileUtils}. */
-@Slf4j
 class FileUtilsTest {
+
+  private static final Logger log = LoggerFactory.getLogger(FileUtilsTest.class);
 
   // The directories used for testing
   static final File originalDir = new File("src/test/resources/JarUtilsResources");

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/util/MavenInvokerTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/util/MavenInvokerTest.java
@@ -5,13 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link MavenInvoker}. */
-@Slf4j
 class MavenInvokerTest {
 
   static final File expectedTree =

--- a/lombok.config
+++ b/lombok.config
@@ -1,4 +1,0 @@
-config.stopBubbling = true
-lombok.addLombokGeneratedAnnotation = true
-lombok.anyConstructor.addConstructorProperties = true
-lombok.extern.findbugs.addSuppressFBWarnings = true 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
     <error_prone_core.version>2.50.0</error_prone_core.version>
     <jspecify.version>1.0.1</jspecify.version>
     <junit-jupiter.version>6.1.3</junit-jupiter.version>
-    <lombok.version>1.18.46</lombok.version>
     <maven-core.version>3.9.16</maven-core.version>
     <nullaway.version>0.14.0</nullaway.version>
     <slf4j-reload4j.version>2.0.18</slf4j-reload4j.version>
@@ -64,12 +63,6 @@
   <!-- List of global dependencies -->
   <dependencies>
     <!-- Utils -->
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>${lombok.version}</version>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
@@ -173,11 +166,6 @@
             <arg>-Xplugin:ErrorProne -XepOpt:NullAway:AnnotatedPackages=se.kth.depclean</arg>
           </compilerArgs>
           <annotationProcessorPaths>
-            <path>
-              <groupId>org.projectlombok</groupId>
-              <artifactId>lombok</artifactId>
-              <version>${lombok.version}</version>
-            </path>
             <path>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>


### PR DESCRIPTION
## What

Removes Lombok as a dependency of DepClean itself — all annotations replaced with plain Java across `depclean-core`, `depclean-maven-plugin`, and `depclean-gradle-plugin`.

## How

| Lombok | Replacement |
|---|---|
| `@Slf4j` (27×) | explicit `LoggerFactory.getLogger` constants; dropped entirely in classes that never logged |
| `@Getter` (16×) | handwritten getters, Lombok naming preserved |
| `@SneakyThrows` (11×) | real `throws` declarations where signatures allow (`DepCleanManager.execute` now declares `AnalysisFailureException, IOException`); `RuntimeException` wrapping inside lambdas/interface methods |
| `@AllArgsConstructor` (10×) | explicit constructors, field order preserved |
| `@EqualsAndHashCode`/`@ToString`/`@Data` | handwritten members preserving Lombok semantics (incl. `Class(field=value)` toString format) |
| `lombok.NonNull` | jspecify `@NonNull` (rest of codebase already uses it) |

Build wiring removed: parent pom dependency + annotation processor path, Gradle `compileOnly`/`annotationProcessor` entries, root `lombok.config`.

## Deliberately kept

The `all_dependencies_used` IT fixture still uses Lombok **as test data** — it covers DepClean's detection of compile-time-only annotation processors as *used* dependencies (via `addLombokGeneratedAnnotation = true` bytecode traces). That coverage is orthogonal to this refactor.

## Verification

- `mvn clean verify`: all modules green, ITs 10/10 (2 skipped as always)
- `./gradlew clean publishToMavenLocal build`: green
- NullAway/Error Prone/Checkstyle/Spotless all pass