### PR TITLE
#399 NullPointerException when dependency coordinates use property placeholders

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,13 +39,21 @@ jobs:
         run: mvn -ntp clean verify --errors
 
         # The following is only executed on Ubuntu on Java 21
-      - name: "Codecov"
+      - name: "Codecov (unit tests)"
         if: matrix.os == 'ubuntu-latest' && matrix.java == 21 && github.repository == 'ASSERT-KTH/depclean'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./depclean-maven-plugin/target/site/jacoco/jacoco.xml,./depclean-maven-plugin/target/site/jacoco-it/jacoco.xml,./depclean-core/target/site/jacoco/jacoco.xml
+          files: ./depclean-maven-plugin/target/site/jacoco/jacoco.xml,./depclean-core/target/site/jacoco/jacoco.xml
           flags: unittests
+
+      - name: "Codecov (integration tests)"
+        if: matrix.os == 'ubuntu-latest' && matrix.java == 21 && github.repository == 'ASSERT-KTH/depclean'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./depclean-maven-plugin/target/site/jacoco-it/jacoco.xml
+          flags: integration
 
       # SonarCloud analysis runs via the SonarCloud GitHub app (Automatic Analysis),
       # so no CI-based sonar:sonar step is needed here.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./depclean-maven-plugin/target/site/jacoco/jacoco.xml,./depclean-core/target/site/jacoco/jacoco.xml
+          files: ./depclean-maven-plugin/target/site/jacoco/jacoco.xml,./depclean-maven-plugin/target/site/jacoco-it/jacoco.xml,./depclean-core/target/site/jacoco/jacoco.xml
           flags: unittests
 
       # SonarCloud analysis runs via the SonarCloud GitHub app (Automatic Analysis),

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -261,4 +261,21 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- When JaCoCo is skipped, prepare-agent-integration never sets itCoverageAgent;
+         define it as empty here so failsafe does not pass the literal expression as MAVEN_OPTS -->
+    <profile>
+      <id>jacoco-skipped</id>
+      <activation>
+        <property>
+          <name>jacoco.skip</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <itCoverageAgent />
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -34,7 +34,8 @@
 
     <!-- Build settings -->
     <checkstyle.config.location>../checkstyle.xml</checkstyle.config.location>
-    <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <sonar.coverage.jacoco.xmlReportPaths>
+      target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <!-- Build options -->
@@ -153,12 +154,40 @@
           <includes>
             <include>**/*IT.java</include>
           </includes>
+          <!-- Instrument the Maven processes forked by the ITs with the JaCoCo agent -->
+          <environmentVariables>
+            <MAVEN_OPTS>${itCoverageAgent}</MAVEN_OPTS>
+          </environmentVariables>
         </configuration>
         <executions>
           <execution>
             <goals>
               <goal>integration-test</goal>
               <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Collect coverage from the Maven processes forked by the integration tests -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>prepare-agent-integration</id>
+            <goals>
+              <goal>prepare-agent-integration</goal>
+            </goals>
+            <configuration>
+              <propertyName>itCoverageAgent</propertyName>
+            </configuration>
+          </execution>
+          <execution>
+            <id>report-integration</id>
+            <goals>
+              <goal>report-integration</goal>
             </goals>
           </execution>
         </executions>

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -158,6 +158,7 @@
           <execution>
             <goals>
               <goal>integration-test</goal>
+              <goal>verify</goal>
             </goals>
           </execution>
         </executions>

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/graph/MavenDependencyGraph.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/graph/MavenDependencyGraph.java
@@ -11,6 +11,8 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Model;
@@ -26,6 +28,8 @@ import se.kth.depclean.core.model.Dependency;
 public class MavenDependencyGraph implements DependencyGraph {
 
   private static final Logger log = LoggerFactory.getLogger(MavenDependencyGraph.class);
+
+  private static final Pattern PROPERTY_PATTERN = Pattern.compile("\\$\\{([^}]+)}");
 
   private final Set<Dependency> allDependencies;
   private final MavenProject project;
@@ -197,15 +201,19 @@ public class MavenDependencyGraph implements DependencyGraph {
         artifact.getFile());
   }
 
-  private Dependency toDepCleanDependency(org.apache.maven.model.Dependency dependency) {
+  private Optional<Dependency> findDepCleanDependency(
+      org.apache.maven.model.Dependency dependency) {
     for (Dependency artifact : allDependencies) {
       if (matches(artifact, dependency)) {
-        return Optional.of(artifact).get();
+        return Optional.of(artifact);
       }
     }
-    // This should never happen.
-    throw new IllegalStateException(
-        "Could not find dependency: " + dependency.getGroupId() + ":" + dependency.getArtifactId());
+    log.warn(
+        "DepClean could not match the declared dependency {}:{} with any resolved artifact; "
+            + "it will be excluded from the direct dependencies analysis.",
+        dependency.getGroupId(),
+        dependency.getArtifactId());
+    return Optional.empty();
   }
 
   private boolean matches(
@@ -213,11 +221,40 @@ public class MavenDependencyGraph implements DependencyGraph {
     return dependencyCoordinate
             .getGroupId()
             .toLowerCase(Locale.ROOT)
-            .equals(dependency.getGroupId().toLowerCase(Locale.ROOT))
+            .equals(interpolate(dependency.getGroupId()).toLowerCase(Locale.ROOT))
         && dependencyCoordinate
             .getDependencyId()
             .toLowerCase(Locale.ROOT)
-            .equals(dependency.getArtifactId().toLowerCase(Locale.ROOT));
+            .equals(interpolate(dependency.getArtifactId()).toLowerCase(Locale.ROOT));
+  }
+
+  /**
+   * Resolves {@code ${...}} placeholders in raw pom coordinates (e.g. {@code
+   * <groupId>${slf4j.groupId}</groupId>}) since the model is read from the pom file without
+   * interpolation. See https://github.com/ASSERT-KTH/depclean/issues/399.
+   */
+  private String interpolate(String value) {
+    if (value == null || !value.contains("${")) {
+      return value == null ? "" : value;
+    }
+    Matcher matcher = PROPERTY_PATTERN.matcher(value);
+    StringBuilder result = new StringBuilder();
+    while (matcher.find()) {
+      String resolved = resolveProperty(matcher.group(1));
+      matcher.appendReplacement(
+          result, Matcher.quoteReplacement(resolved == null ? matcher.group(0) : resolved));
+    }
+    matcher.appendTail(result);
+    return result.toString();
+  }
+
+  private String resolveProperty(String key) {
+    return switch (key) {
+      case "project.groupId", "pom.groupId" -> project.getGroupId();
+      case "project.artifactId", "pom.artifactId" -> project.getArtifactId();
+      case "project.version", "pom.version" -> project.getVersion();
+      default -> project.getProperties().getProperty(key);
+    };
   }
 
   private ImmutableSet<Dependency> getAllDependencies(MavenProject project) {
@@ -228,7 +265,8 @@ public class MavenDependencyGraph implements DependencyGraph {
 
   private ImmutableSet<Dependency> getDirectDependencies(Model model) {
     return model.getDependencies().stream()
-        .map(this::toDepCleanDependency)
+        .map(this::findDepCleanDependency)
+        .flatMap(Optional::stream)
         .collect(toImmutableSet());
   }
 }

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
@@ -60,6 +60,25 @@ public class DepCleanMojoIT {
   }
 
   @MavenTest
+  void property_in_dependency_coordinates(MavenExecutionResult result) {
+    log.trace(
+        "Test that DepClean does not crash when dependency coordinates use property placeholders"
+            + " (issue #399)");
+    assertThat(result)
+        .isSuccessful()
+        .out()
+        .plain()
+        .contains(
+            "-------------------------------------------------------",
+            " D E P C L E A N   A N A L Y S I S   R E S U L T S",
+            "-------------------------------------------------------",
+            "USED DIRECT DEPENDENCIES [1]: ",
+            "	commons-io:commons-io:2.11.0:compile (319 KB)",
+            "USED TRANSITIVE DEPENDENCIES [0]: ",
+            "POTENTIALLY UNUSED DIRECT DEPENDENCIES [0]: ");
+  }
+
+  @MavenTest
   void all_dependencies_unused(MavenExecutionResult result) {
     log.trace("Test that DepClean identifies all dependencies as unused");
     assertThat(result)

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/graph/MavenDependencyGraphTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/graph/MavenDependencyGraphTest.java
@@ -1,0 +1,174 @@
+package se.kth.depclean.graph;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.model.Exclusion;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
+import org.junit.jupiter.api.Test;
+import se.kth.depclean.core.model.Dependency;
+
+/**
+ * Tests that declared dependencies whose coordinates use property placeholders (e.g. {@code
+ * <groupId>${slf4j.groupId}</groupId>}) are matched against resolved artifacts instead of crashing
+ * the analysis. See https://github.com/ASSERT-KTH/depclean/issues/399.
+ */
+class MavenDependencyGraphTest {
+
+  private static final String PROJECT_GROUP_ID = "org.foo.bar";
+
+  @Test
+  void resolvesPropertyPlaceholdersInDependencyCoordinates() {
+    MavenProject project = createProject();
+    project.getProperties().setProperty("io.groupId", "commons-io");
+    project.getProperties().setProperty("io.artifactId", "commons-io");
+
+    Model rawModel = new Model();
+    rawModel.addDependency(createModelDependency("${io.groupId}", "${io.artifactId}", "2.11.0"));
+
+    MavenDependencyGraph graph = new MavenDependencyGraph(project, rawModel, rootNode(project));
+
+    assertThat(graph.directDependencies())
+        .extracting(Dependency::getGroupId, Dependency::getDependencyId)
+        .containsExactly(org.assertj.core.groups.Tuple.tuple("commons-io", "commons-io"));
+  }
+
+  @Test
+  void resolvesProjectBuiltInPlaceholders() {
+    MavenProject project = createProject();
+
+    Model rawModel = new Model();
+    rawModel.addDependency(createModelDependency("${project.groupId}", "sibling", "1.0.0"));
+
+    MavenDependencyGraph graph = new MavenDependencyGraph(project, rawModel, rootNode(project));
+
+    assertThat(graph.directDependencies())
+        .extracting(Dependency::getGroupId, Dependency::getDependencyId)
+        .containsExactly(org.assertj.core.groups.Tuple.tuple(PROJECT_GROUP_ID, "sibling"));
+  }
+
+  @Test
+  void matchesLiteralCoordinates() {
+    MavenProject project = createProject();
+
+    Model rawModel = new Model();
+    rawModel.addDependency(createModelDependency("commons-io", "commons-io", "2.11.0"));
+
+    MavenDependencyGraph graph = new MavenDependencyGraph(project, rawModel, rootNode(project));
+
+    assertThat(graph.directDependencies())
+        .extracting(Dependency::getGroupId, Dependency::getDependencyId)
+        .containsExactly(org.assertj.core.groups.Tuple.tuple("commons-io", "commons-io"));
+  }
+
+  @Test
+  void skipsDependencyThatCannotBeMatched() {
+    MavenProject project = createProject();
+
+    Model rawModel = new Model();
+    rawModel.addDependency(createModelDependency("commons-io", "commons-io", "2.11.0"));
+    rawModel.addDependency(createModelDependency("${undefined.groupId}", "unknown", "1.0.0"));
+
+    assertThatCode(() -> new MavenDependencyGraph(project, rawModel, rootNode(project)))
+        .doesNotThrowAnyException();
+
+    MavenDependencyGraph graph = new MavenDependencyGraph(project, rawModel, rootNode(project));
+    assertThat(graph.directDependencies())
+        .extracting(Dependency::getGroupId, Dependency::getDependencyId)
+        .containsExactly(org.assertj.core.groups.Tuple.tuple("commons-io", "commons-io"));
+  }
+
+  private MavenProject createProject() {
+    MavenProject project = new MavenProject();
+    project.setGroupId(PROJECT_GROUP_ID);
+    project.setArtifactId("foobar");
+    project.setVersion("1.0.0-SNAPSHOT");
+    Set<Artifact> resolvedArtifacts =
+        Set.of(
+            createArtifact("commons-io", "commons-io", "2.11.0"),
+            createArtifact(PROJECT_GROUP_ID, "sibling", "1.0.0"));
+    project.setArtifacts(resolvedArtifacts);
+    project.setDependencyArtifacts(resolvedArtifacts);
+    return project;
+  }
+
+  private Artifact createArtifact(String groupId, String artifactId, String version) {
+    return new DefaultArtifact(
+        groupId, artifactId, version, "compile", "jar", "", new DefaultArtifactHandler("jar"));
+  }
+
+  private org.apache.maven.model.Dependency createModelDependency(
+      String groupId, String artifactId, String version) {
+    org.apache.maven.model.Dependency dependency = new org.apache.maven.model.Dependency();
+    dependency.setGroupId(groupId);
+    dependency.setArtifactId(artifactId);
+    dependency.setVersion(version);
+    return dependency;
+  }
+
+  private DependencyNode rootNode(MavenProject project) {
+    Artifact rootArtifact =
+        createArtifact(project.getGroupId(), project.getArtifactId(), project.getVersion());
+    return new DependencyNode() {
+      @Override
+      public Artifact getArtifact() {
+        return rootArtifact;
+      }
+
+      @Override
+      public List<DependencyNode> getChildren() {
+        return List.of();
+      }
+
+      @Override
+      public boolean accept(DependencyNodeVisitor visitor) {
+        return false;
+      }
+
+      @Override
+      @SuppressWarnings("NullAway") // root node has no parent; not used by the code under test
+      public DependencyNode getParent() {
+        return null;
+      }
+
+      @Override
+      public String getPremanagedVersion() {
+        return "";
+      }
+
+      @Override
+      public String getPremanagedScope() {
+        return "";
+      }
+
+      @Override
+      public String getVersionConstraint() {
+        return "";
+      }
+
+      @Override
+      public String toNodeString() {
+        return "";
+      }
+
+      @Override
+      public Boolean getOptional() {
+        return Boolean.FALSE;
+      }
+
+      @Override
+      public List<Exclusion> getExclusions() {
+        return List.of();
+      }
+    };
+  }
+}

--- a/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanMojoIT/property_in_dependency_coordinates/pom.xml
+++ b/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanMojoIT/property_in_dependency_coordinates/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.foo.bar</groupId>
+  <artifactId>foobar</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>foobar</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <!-- Properties used in dependency coordinates, see https://github.com/ASSERT-KTH/depclean/issues/399.
+         Names must not collide with properties of the DepClean build itself, because the
+         integration-test framework filters this pom with the outer build's properties. -->
+    <it.commons-io.groupId>commons-io</it.commons-io.groupId>
+    <it.commons-io.artifactId>commons-io</it.commons-io.artifactId>
+    <it.commons-io.version>2.11.0</it.commons-io.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${it.commons-io.groupId}</groupId>
+      <artifactId>${it.commons-io.artifactId}</artifactId>
+      <version>${it.commons-io.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>se.kth.castor</groupId>
+        <artifactId>depclean-maven-plugin</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>depclean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanMojoIT/property_in_dependency_coordinates/src/main/java/Main.java
+++ b/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanMojoIT/property_in_dependency_coordinates/src/main/java/Main.java
@@ -1,0 +1,14 @@
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+
+/**
+ * Uses commons-io, which is declared in the pom with property placeholders in its coordinates.
+ */
+public class Main {
+
+  public static void main(String[] args) throws IOException {
+    FileUtils.writeStringToFile(new File("output.txt"), "Hello DepClean!", StandardCharsets.UTF_8);
+  }
+}


### PR DESCRIPTION
#399

DepClean reads the raw `pom.xml` without property interpolation, so a dependency declared with a property placeholder in its coordinates (e.g. `<groupId>${slf4j.groupId}</groupId>`) can never be matched against the resolved artifacts. In 2.0.6/2.1.0 this crashed with a `NullPointerException`; on current master it crashes with `IllegalStateException: Could not find dependency`.

Changes:

* `MavenDependencyGraph`: interpolate `${...}` placeholders from the project's effective properties (plus the `project.groupId`/`artifactId`/`version` built-ins) before matching declared dependencies against resolved artifacts
* `MavenDependencyGraph`: if a declared dependency still cannot be matched, log a warning and exclude it from the direct-dependency analysis instead of failing the whole build
* Added integration test `property_in_dependency_coordinates` that reproduces the reported crash (verified it fails without the fix and passes with it)
* Bound the failsafe `verify` goal so integration test failures actually fail the build (previously only `integration-test` was bound, so IT failures were silently ignored)

Verified locally with `mvn clean verify` (Java 21): all unit tests and all 11 integration tests pass.