### PR TITLE
fix(gradle-plugin): resolve class dirs from source sets and Android variant layouts

### DIFF
--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/DepCleanGradleAction.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/DepCleanGradleAction.java
@@ -34,6 +34,7 @@ import org.jspecify.annotations.Nullable;
 import se.kth.depclean.analysis.DefaultGradleProjectDependencyAnalyzer;
 import se.kth.depclean.analysis.GradleProjectDependencyAnalysis;
 import se.kth.depclean.core.util.JarUtils;
+import se.kth.depclean.utils.ClassesDirectoryFinder;
 import se.kth.depclean.utils.DependencyUtils;
 import se.kth.depclean.utils.GradleWritingUtils;
 import se.kth.depclean.utils.json.JsonResultWriter;
@@ -92,9 +93,6 @@ public class DepCleanGradleAction implements Action<Project> {
     // Path to the libs directory.
     final Path libsDirPath = projectDirPath.resolve(Paths.get("build", "libs"));
 
-    // Path to the build classes directory.
-    final Path classesDirPath = projectDirPath.resolve(Paths.get("build", "classes"));
-
     DependencyUtils utils = new DependencyUtils();
 
     // Project's configurations - only get resolvable ones to avoid deprecated API
@@ -138,10 +136,13 @@ public class DepCleanGradleAction implements Action<Project> {
       }
     }
 
-    // First, add the size of the project, as the sum of all the files in
-    // target/classes
+    // First, add the size of the project, as the sum of all the compiled class directories
+    // (source sets and Android variants included).
     String projectJar = project.getName() + "-" + project.getVersion() + ".jar";
-    long projectSize = FileUtils.sizeOf(classesDirPath.toFile());
+    long projectSize = 0;
+    for (File classesDir : ClassesDirectoryFinder.findClassesDirectories(project, isIgnoreTest)) {
+      projectSize += FileUtils.sizeOf(classesDir);
+    }
     SizeOfDependencies.put(projectJar, projectSize);
 
     /*

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/analysis/DefaultGradleProjectDependencyAnalyzer.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/analysis/DefaultGradleProjectDependencyAnalyzer.java
@@ -28,6 +28,7 @@ import se.kth.depclean.core.analysis.DependencyTypes;
 import se.kth.depclean.core.analysis.asm.AsmDependencyAnalyzer;
 import se.kth.depclean.core.analysis.graph.DefaultCallGraph;
 import se.kth.depclean.core.model.ClassName;
+import se.kth.depclean.utils.ClassesDirectoryFinder;
 import se.kth.depclean.utils.DependencyUtils;
 
 /** This is principal class that perform the dependency analysis in a Gradle project. */
@@ -190,24 +191,9 @@ public class DefaultGradleProjectDependencyAnalyzer implements GradleProjectDepe
    * @throws IOException In case of IO issues.
    */
   private void buildProjectDependencyClasses(final Project project) throws IOException {
-    Path classesDir = Paths.get(project.getProjectDir().getAbsolutePath(), "build", "classes");
-
-    // Analyze src classes in the project
-    File outputJavaDir = classesDir.resolve("java").resolve("main").toFile();
-    File outputGroovyDir = classesDir.resolve("groovy").resolve("main").toFile();
-    File outputKotlinDir = classesDir.resolve("kotlin").resolve("main").toFile();
-    checkThenCollectDependencyClasses(outputJavaDir);
-    checkThenCollectDependencyClasses(outputGroovyDir);
-    checkThenCollectDependencyClasses(outputKotlinDir);
-
-    // Analyze test classes in the project
-    if (!isIgnoredTest) {
-      File testOutputJavaDir = classesDir.resolve("java").resolve("test").toFile();
-      File testOutputGroovyDir = classesDir.resolve("groovy").resolve("test").toFile();
-      File testOutputKotlinDir = classesDir.resolve("kotlin").resolve("test").toFile();
-      checkThenCollectDependencyClasses(testOutputJavaDir);
-      checkThenCollectDependencyClasses(testOutputGroovyDir);
-      checkThenCollectDependencyClasses(testOutputKotlinDir);
+    // Analyze classes from all source sets and layouts (JVM, custom, Android variants)
+    for (File classesDir : ClassesDirectoryFinder.findClassesDirectories(project, isIgnoredTest)) {
+      checkThenCollectDependencyClasses(classesDir);
     }
   }
 

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/ClassesDirectoryFinder.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/ClassesDirectoryFinder.java
@@ -1,0 +1,105 @@
+package se.kth.depclean.utils;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
+
+/**
+ * Resolves the directories containing the compiled classes of a Gradle project.
+ *
+ * <p>Instead of assuming the conventional JVM layout ({@code build/classes/java/main}), this finder
+ * resolves the output directories registered in the project's {@link SourceSetContainer} (covering
+ * custom source sets and languages), scans the conventional {@code build/classes} layout for any
+ * language and source set, and additionally supports Android layouts such as {@code
+ * build/intermediates/javac/[variant]/classes} and {@code build/tmp/kotlin-classes/[variant]}
+ * (multi-flavor variants included).
+ */
+public final class ClassesDirectoryFinder {
+
+  private ClassesDirectoryFinder() {}
+
+  /**
+   * Finds all existing directories with compiled classes of the given project.
+   *
+   * @param project The Gradle project.
+   * @param ignoreTests If true, test source sets and test variants are excluded.
+   * @return The existing class output directories, possibly empty.
+   */
+  public static Set<File> findClassesDirectories(final Project project, final boolean ignoreTests) {
+    Set<File> result = new LinkedHashSet<>();
+    addSourceSetOutputs(project, ignoreTests, result);
+    File buildDir = new File(project.getProjectDir(), "build");
+    addConventionalLayout(new File(buildDir, "classes"), ignoreTests, result);
+    addVariantLayout(new File(new File(buildDir, "intermediates"), "javac"), ignoreTests, result);
+    addVariantLayout(new File(new File(buildDir, "tmp"), "kotlin-classes"), ignoreTests, result);
+    return result;
+  }
+
+  /** Collects the class output directories registered in the project's source sets. */
+  private static void addSourceSetOutputs(
+      final Project project, final boolean ignoreTests, final Set<File> result) {
+    SourceSetContainer sourceSets = project.getExtensions().findByType(SourceSetContainer.class);
+    if (sourceSets == null) {
+      return;
+    }
+    for (SourceSet sourceSet : sourceSets) {
+      if (ignoreTests && isTestName(sourceSet.getName())) {
+        continue;
+      }
+      for (File dir : sourceSet.getOutput().getClassesDirs().getFiles()) {
+        if (dir.isDirectory()) {
+          result.add(dir);
+        }
+      }
+    }
+  }
+
+  /** Scans the conventional {@code build/classes/<language>/<sourceSet>} layout. */
+  private static void addConventionalLayout(
+      final File classesDir, final boolean ignoreTests, final Set<File> result) {
+    File[] languages = classesDir.listFiles(File::isDirectory);
+    if (languages == null) {
+      return;
+    }
+    for (File language : languages) {
+      File[] sourceSetDirs = language.listFiles(File::isDirectory);
+      if (sourceSetDirs == null) {
+        continue;
+      }
+      for (File sourceSetDir : sourceSetDirs) {
+        if (ignoreTests && isTestName(sourceSetDir.getName())) {
+          continue;
+        }
+        result.add(sourceSetDir);
+      }
+    }
+  }
+
+  /**
+   * Scans Android per-variant layouts. For {@code intermediates/javac} the classes live in a {@code
+   * classes} subdirectory of each variant; for {@code tmp/kotlin-classes} the variant directory
+   * itself contains the classes.
+   */
+  private static void addVariantLayout(
+      final File variantsDir, final boolean ignoreTests, final Set<File> result) {
+    File[] variants = variantsDir.listFiles(File::isDirectory);
+    if (variants == null) {
+      return;
+    }
+    for (File variant : variants) {
+      if (ignoreTests && isTestName(variant.getName())) {
+        continue;
+      }
+      File classesSubDir = new File(variant, "classes");
+      result.add(classesSubDir.isDirectory() ? classesSubDir : variant);
+    }
+  }
+
+  private static boolean isTestName(final String name) {
+    return name.toLowerCase(Locale.ROOT).contains("test");
+  }
+}

--- a/depclean-gradle-plugin/src/test/groovy/se/kth/depclean/DepCleanGradleFT.groovy
+++ b/depclean-gradle-plugin/src/test/groovy/se/kth/depclean/DepCleanGradleFT.groovy
@@ -1,6 +1,5 @@
 package se.kth.depclean
 
-import org.apache.maven.BuildFailureException
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
@@ -21,17 +20,12 @@ class DepCleanGradleFT extends Specification {
 
         when:
         project.plugins.apply("se.kth.castor.depclean-gradle-plugin")
+        // No compiled classes exist: debloat must succeed gracefully instead of
+        // crashing with "build/classes does not exist" (issue #218)
+        BuildResult debloatResult = createRunner(emptyProjectFile, "debloat")
 
         then:
-        try {
-            BuildResult result = GradleRunner.create()
-                    .withProjectDir(emptyProjectFile)
-                    .withArguments("debloat")
-                    .withDebug(true)
-                    .buildAndFail()
-        } catch (Exception e) {
-            assert e.class == BuildFailureException
-        }
+        assert checkTaskOutcome(debloatResult.task(":debloat").getOutcome())
     }
 
     String projectPath1 = "src/test/resources-fts/all_dependencies_unused"

--- a/depclean-gradle-plugin/src/test/groovy/se/kth/depclean/utils/ClassesDirectoryFinderSpec.groovy
+++ b/depclean-gradle-plugin/src/test/groovy/se/kth/depclean/utils/ClassesDirectoryFinderSpec.groovy
@@ -1,0 +1,162 @@
+package se.kth.depclean.utils
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class ClassesDirectoryFinderSpec extends Specification {
+
+    @TempDir
+    File projectDir
+
+    private Project buildProject(boolean withJavaPlugin = false) {
+        Project project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        if (withJavaPlugin) {
+            project.plugins.apply("java")
+        }
+        return project
+    }
+
+    private File mkdirs(String... segments) {
+        File dir = new File(projectDir, segments.join(File.separator))
+        assert dir.mkdirs() || dir.isDirectory()
+        return dir
+    }
+
+    def "returns an empty set when no class directories exist"() {
+        given:
+        Project project = buildProject()
+
+        expect:
+        ClassesDirectoryFinder.findClassesDirectories(project, false).isEmpty()
+    }
+
+    def "returns an empty set when build/classes does not exist without failing"() {
+        given: "a java project that was never compiled (issue #218 crash scenario)"
+        Project project = buildProject(true)
+
+        expect:
+        ClassesDirectoryFinder.findClassesDirectories(project, false).isEmpty()
+    }
+
+    def "finds main and test classes in the conventional JVM layout"() {
+        given:
+        Project project = buildProject(true)
+        File mainClasses = mkdirs("build", "classes", "java", "main")
+        File testClasses = mkdirs("build", "classes", "java", "test")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, false)
+
+        then:
+        result.contains(mainClasses)
+        result.contains(testClasses)
+    }
+
+    def "excludes test source sets when tests are ignored"() {
+        given:
+        Project project = buildProject(true)
+        File mainClasses = mkdirs("build", "classes", "java", "main")
+        File testClasses = mkdirs("build", "classes", "java", "test")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, true)
+
+        then:
+        result.contains(mainClasses)
+        !result.contains(testClasses)
+    }
+
+    def "finds groovy and kotlin classes in the conventional layout"() {
+        given:
+        Project project = buildProject()
+        File groovyClasses = mkdirs("build", "classes", "groovy", "main")
+        File kotlinClasses = mkdirs("build", "classes", "kotlin", "main")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, false)
+
+        then:
+        result.containsAll([groovyClasses, kotlinClasses])
+    }
+
+    def "finds custom source set output directories"() {
+        given:
+        Project project = buildProject(true)
+        project.sourceSets.create("integration")
+        File integrationClasses = mkdirs("build", "classes", "java", "integration")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, false)
+
+        then:
+        result.contains(integrationClasses)
+    }
+
+    def "finds Android javac classes for multiple product flavors"() {
+        given: "the Android layout reported in issue #218"
+        Project project = buildProject()
+        File devDebug = mkdirs("build", "intermediates", "javac", "devDebug", "classes")
+        File prodRelease = mkdirs("build", "intermediates", "javac", "prodRelease", "classes")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, false)
+
+        then:
+        result.containsAll([devDebug, prodRelease])
+    }
+
+    def "excludes Android test variants when tests are ignored"() {
+        given:
+        Project project = buildProject()
+        File devDebug = mkdirs("build", "intermediates", "javac", "devDebug", "classes")
+        File unitTest = mkdirs("build", "intermediates", "javac", "devDebugUnitTest", "classes")
+        File androidTest = mkdirs("build", "intermediates", "javac", "devDebugAndroidTest", "classes")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, true)
+
+        then:
+        result.contains(devDebug)
+        !result.contains(unitTest)
+        !result.contains(androidTest)
+    }
+
+    def "includes Android test variants when tests are not ignored"() {
+        given:
+        Project project = buildProject()
+        File unitTest = mkdirs("build", "intermediates", "javac", "devDebugUnitTest", "classes")
+
+        expect:
+        ClassesDirectoryFinder.findClassesDirectories(project, false).contains(unitTest)
+    }
+
+    def "finds Android kotlin classes per variant"() {
+        given:
+        Project project = buildProject()
+        File debug = mkdirs("build", "tmp", "kotlin-classes", "debug")
+        File releaseTest = mkdirs("build", "tmp", "kotlin-classes", "debugUnitTest")
+
+        when:
+        Set<File> resultWithTests = ClassesDirectoryFinder.findClassesDirectories(project, false)
+        Set<File> resultWithoutTests = ClassesDirectoryFinder.findClassesDirectories(project, true)
+
+        then:
+        resultWithTests.containsAll([debug, releaseTest])
+        resultWithoutTests.contains(debug)
+        !resultWithoutTests.contains(releaseTest)
+    }
+
+    def "does not duplicate directories reported by both source sets and layout scan"() {
+        given:
+        Project project = buildProject(true)
+        File mainClasses = mkdirs("build", "classes", "java", "main")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, false)
+
+        then:
+        result.count { it == mainClasses } == 1
+    }
+}


### PR DESCRIPTION
## What

Fixes the Gradle plugin's hardcoded class-directory resolution that made it fail on Android, multi-module, and multi-product-flavor projects with:

```
> C:\my\path\to\project\build\classes does not exist
```

Fixes #218

## Why

The plugin assumed the conventional JVM layout in two places:

- `DefaultGradleProjectDependencyAnalyzer` only analyzed `build/classes/{java,groovy,kotlin}/{main,test}`
- `DepCleanGradleAction` called `FileUtils.sizeOf(build/classes)`, which throws when that directory doesn't exist — the exact crash reported in the issue

Android projects place compiled classes in e.g. `build/intermediates/javac/<flavor><BuildType>/classes`, so nothing was found (or the plugin crashed outright).

## How

New `ClassesDirectoryFinder` utility resolves class output directories from three sources (deduplicated):

1. **Gradle `SourceSetContainer`** — covers custom source sets and any registered JVM language
2. **Generic scan of `build/classes/<language>/<sourceSet>`** — no longer limited to hardcoded language/source-set names
3. **Android layouts** — `build/intermediates/javac/<variant>/classes` and `build/tmp/kotlin-classes/<variant>`, multi-flavor variants included

Test source sets and `*Test*` variants (e.g. `devDebugUnitTest`, `devDebugAndroidTest`) are excluded when `ignoreTest` is enabled. The project size computation now sums over the resolved directories and no longer crashes when `build/classes` is absent.

## Tests

New `ClassesDirectoryFinderSpec` (Spock) with 11 cases:

- empty project and never-compiled java project (the issue's crash scenario) → empty result, no exception
- conventional main/test layouts, groovy/kotlin, custom source sets
- Android javac multi-flavor variants, test-variant exclusion/inclusion, kotlin-classes variants
- dedup between source-set outputs and layout scan

All 5 existing functional tests still pass; `./gradlew check` (incl. spotless, Error Prone/NullAway) is green.