### PR TITLE
#168 Fix Renovate config warnings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,16 +17,20 @@
       "description": "Gradle 9 embeds Groovy 4; keep Spock on the -groovy-4.0 variant",
       "matchPackageNames": ["org.spockframework:spock-core"],
       "allowedVersions": "/-groovy-4\\.0$/"
+    },
+    {
+      "description": "Security fix PRs get top priority",
+      "matchJsonata": ["isVulnerabilityAlert"],
+      "prPriority": 10
     }
   ],
   "vulnerabilityAlerts": {
     "description": "Security fixes skip the cooldown and get merged immediately",
-    "minimumReleaseAge": null,
-    "prPriority": 10
+    "minimumReleaseAge": null
   },
   "osvVulnerabilityAlerts": true,
   "platformAutomerge": true,
-  "includeForks": true,
+  "forkProcessing": "enabled",
   "dependencyDashboard": true,
   "prConcurrentLimit": 5
 }


### PR DESCRIPTION
#168 The dependency dashboard reports "Config Migration Needed" and "Found renovate config warnings". Verified with `renovate-config-validator` (validates clean now).

- Migrate deprecated `includeForks: true` to `forkProcessing: "enabled"`
- Move `prPriority` out of `vulnerabilityAlerts` (not an allowed field there) into a `packageRules` entry matched via `matchJsonata: isVulnerabilityAlert`