### PR TITLE
fix(deps): bump commons-io IT fixture to 2.20.0, let Renovate scan fixture manifests

### DIFF
--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
@@ -75,7 +75,7 @@ public class DepCleanMojoIT {
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",
             "-------------------------------------------------------",
             "USED DIRECT DEPENDENCIES [1]: ",
-            "	commons-io:commons-io:2.11.0:compile (319 KB)",
+            "	commons-io:commons-io:2.20.0:compile (550 KB)",
             "USED TRANSITIVE DEPENDENCIES [0]: ",
             "POTENTIALLY UNUSED DIRECT DEPENDENCIES [0]: ");
   }

--- a/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanMojoIT/property_in_dependency_coordinates/pom.xml
+++ b/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanMojoIT/property_in_dependency_coordinates/pom.xml
@@ -18,7 +18,7 @@
          integration-test framework filters this pom with the outer build's properties. -->
     <it.commons-io.groupId>commons-io</it.commons-io.groupId>
     <it.commons-io.artifactId>commons-io</it.commons-io.artifactId>
-    <it.commons-io.version>2.11.0</it.commons-io.version>
+    <it.commons-io.version>2.20.0</it.commons-io.version>
   </properties>
 
   <dependencies>

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "helpers:pinGitHubActionDigests",
     "group:allNonMajor"
   ],
+  "ignorePaths": ["**/node_modules/**", "**/target/**", "**/build/**"],
   "semanticCommits": "enabled",
   "packageRules": [
     {
@@ -17,6 +18,11 @@
       "description": "Gradle 9 embeds Groovy 4; keep Spock on the -groovy-4.0 variant",
       "matchPackageNames": ["org.spockframework:spock-core"],
       "allowedVersions": "/-groovy-4\\.0$/"
+    },
+    {
+      "description": "Test fixtures reference DepClean's own SNAPSHOT artifacts from mavenLocal; never touch them",
+      "matchPackageNames": ["se.kth.castor:**"],
+      "enabled": false
     },
     {
       "description": "Security fix PRs get top priority",


### PR DESCRIPTION
## What

- Bumps `it.commons-io.version` in the `property_in_dependency_coordinates` IT fixture from 2.11.0 to **2.20.0**, resolving Dependabot alert [#137](https://github.com/ASSERT-KTH/depclean/security/dependabot/137) (GHSA-78wr-2p64-hpwj, high — commons-io < 2.14.0 XmlStreamReader DoS). This was the one fixture pom #494 didn't cover. The golden assertion in `DepCleanMojoIT` is updated to the new version/display size (`2.20.0:compile (550 KB)`).
- Renovate config: `config:recommended` inherits `:ignoreModulesAndTests`, whose `**/test/**` ignore path hid **all** IT/FT fixture manifests (`src/test/resources-its/**/pom.xml`, `src/test/resources-fts/**/*.gradle`) from Renovate — which is why these fixture deps kept rotting until Dependabot flagged them. This PR overrides `ignorePaths` to only exclude `node_modules`/`target`/`build`, so Renovate now scans every pom and Gradle script in the repo.
- Adds a package rule disabling updates for `se.kth.castor:**`, since fixtures reference DepClean's own `2.2.0-SNAPSHOT` from mavenLocal.

## Notes

- Future Renovate bumps of fixture deps will fail the golden-output ITs until the assertions are updated — that's intentional: the PR surfaces the update, and automerge won't fire on red checks.
- Verified locally with `./mvnw clean install`: `property_in_dependency_coordinates` passes with the new output; the only failure is the known JDK25-local 1-byte jar-size discrepancy in `json_should_be_correct` (pinned to CI's JDK21 value).