### PR TITLE
docs: refresh README, add CONTRIBUTING.md and SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to DepClean
+
+Thanks for your interest in contributing! Bug reports, feature suggestions, documentation improvements, and pull requests are all welcome.
+
+## Prerequisites
+
+- Java (Open)JDK 21 or above — the build targets Java 17 bytecode, but CI builds with JDK 21
+- No Maven or Gradle installation needed — both wrappers (`mvnw`, `gradlew`) are included
+
+## Building the project
+
+Clone the repository and build all Maven modules:
+
+```bash
+git clone https://github.com/ASSERT-KTH/depclean.git
+cd depclean
+./mvnw clean install
+```
+
+This is close to what CI runs (`./mvnw clean verify`) and executes unit tests, integration tests, and Checkstyle.
+
+### Gradle plugin
+
+The Gradle plugin (`depclean-gradle-plugin`) resolves `depclean-core` and its own snapshot from your **local Maven repository**, so build the Maven modules first, then publish and test the plugin:
+
+```bash
+./mvnw clean install -DskipTests
+cd depclean-gradle-plugin
+./gradlew clean publishToMavenLocal build
+```
+
+> **Note:** running `./gradlew test` without `publishToMavenLocal` tests the *stale* snapshot in `~/.m2`, not your current code. Always use the command above (it is what CI runs).
+
+## Code style
+
+- Java code follows a [Google Java Style](https://google.github.io/styleguide/javaguide.html)-based configuration enforced by Checkstyle ([checkstyle.xml](checkstyle.xml)). Checkstyle runs as part of the Maven build.
+- The Gradle plugin module uses [Spotless](https://github.com/diffplug/spotless); run `./gradlew spotlessApply` to format.
+
+## Tests
+
+- Unit tests run with `./mvnw test`.
+- The Maven plugin has integration tests (`DepCleanMojoIT`) that execute real Maven builds against fixture projects under `depclean-maven-plugin/src/test/resources-its`. Their assertions compare against golden log output, which embeds exact dependency versions and jar sizes — if you change a fixture, update the expected output from the actual logs under `depclean-maven-plugin/target/maven-it/`.
+- Coverage is collected with JaCoCo and reported to [Codecov](https://codecov.io/gh/ASSERT-KTH/depclean).
+
+## Submitting a pull request
+
+Please follow the checklist in the [pull request template](.github/PULL_REQUEST_TEMPLATE/pull_request_template.md). In short:
+
+1. Keep changes small and focused on a single problem (separate PRs for separate problems).
+2. Run the build locally (`./mvnw clean verify`) and make sure it passes.
+3. Reference the related issue in the PR title and description, and summarize your changes in bullet points.
+4. Be ready to discuss your changes during code review.
+
+## Reporting bugs and requesting features
+
+Use the [issue tracker](https://github.com/ASSERT-KTH/depclean/issues) with the provided templates. For security vulnerabilities, please follow the [security policy](SECURITY.md) instead of opening a public issue.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ If you use DepClean in academic work, please cite the original paper (see also [
 
 ## Contributing
 
-Contributions are welcome! Feel free to open an [issue](https://github.com/ASSERT-KTH/depclean/issues) for bug reports or feature suggestions, or submit a pull request. The [Gradle plugin](depclean-gradle-plugin/README.md) in particular is actively looking for contributors.
+Contributions are welcome! See the [contributing guidelines](CONTRIBUTING.md) for how to build the project and submit a pull request. Feel free to open an [issue](https://github.com/ASSERT-KTH/depclean/issues) for bug reports or feature suggestions — for security vulnerabilities, please follow the [security policy](SECURITY.md) instead. The [Gradle plugin](depclean-gradle-plugin/README.md) in particular is actively looking for contributors.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# DepClean <img src="https://github.com/castor-software/depclean/blob/master/.img/logo.svg" align="left" height="135px" alt="DepClean logo"/>
+# DepClean <img src=".img/logo.svg" align="left" height="135px" alt="DepClean logo"/>
 
-[![build](https://github.com/castor-software/depclean/actions/workflows/build.yml/badge.svg)](https://github.com/castor-software/depclean/actions/workflows/build.yml)
+[![build](https://github.com/ASSERT-KTH/depclean/actions/workflows/build.yml/badge.svg)](https://github.com/ASSERT-KTH/depclean/actions/workflows/build.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ASSERT-KTH_depclean&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ASSERT-KTH_depclean)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ASSERT-KTH_depclean&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ASSERT-KTH_depclean)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ASSERT-KTH_depclean&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=ASSERT-KTH_depclean)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ASSERT-KTH_depclean&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=ASSERT-KTH_depclean)
 [![Maven Central](https://img.shields.io/maven-central/v/se.kth.castor/depclean-core.svg)](https://search.maven.org/search?q=g:se.kth.castor%20AND%20a:depclean*)
-[![Licence](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/castor-software/depclean/blob/master/LICENSE.md)
+[![Licence](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=ASSERT-KTH_depclean&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=ASSERT-KTH_depclean)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ASSERT-KTH_depclean&metric=bugs)](https://sonarcloud.io/summary/new_code?id=ASSERT-KTH_depclean)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ASSERT-KTH_depclean&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=ASSERT-KTH_depclean)
@@ -14,6 +14,19 @@
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=ASSERT-KTH_depclean&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=ASSERT-KTH_depclean)
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=ASSERT-KTH_depclean&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=ASSERT-KTH_depclean)
 [![codecov](https://codecov.io/gh/ASSERT-KTH/depclean/graph/badge.svg?token=X0XE6R72OD)](https://codecov.io/gh/ASSERT-KTH/depclean)
+
+## Table of Contents
+
+- [What is DepClean?](#what-is-depclean)
+- [Usage](#usage)
+- [Optional Parameters](#optional-parameters)
+- [How does DepClean work?](#how-does-depclean-work)
+- [Gradle Plugin](#gradle-plugin)
+- [Installing and building from source](#installing-and-building-from-source)
+- [Citation](#citation)
+- [Contributing](#contributing)
+- [License](#license)
+- [Funding](#funding)
 
 ## What is DepClean?
 
@@ -36,7 +49,7 @@ Importantly, **DepClean does *not* modify your source code or original `pom.xml`
 * Includes support for annotation processors.
 * Analyzes fat JARs, shaded dependencies, and repackaged libraries.
 
-For a visual overview of how DepClean works and what it can do for your project, check out the companion project: [**depclean-web**](https://github.com/castor-software/depclean-web).
+For a visual overview of how DepClean works and what it can do for your project, check out the companion project: [**depclean-web**](https://github.com/ASSERT-KTH/depclean-web).
 
 ✨ **DepClean is the result of academic research** conducted at [KTH Royal Institute of Technology](https://www.kth.se/en) in Sweden. It was introduced in the paper:
 ["A Comprehensive Study of Bloated Dependencies in the Maven Ecosystem"](http://arxiv.org/pdf/2001.07808) ([DOI: 10.1007/s10664-020-09914-8](https://doi.org/10.1007/s10664-020-09914-8))
@@ -49,7 +62,7 @@ Configure the `pom.xml` file of your Maven project to use DepClean as part of th
 <plugin>
   <groupId>se.kth.castor</groupId>
   <artifactId>depclean-maven-plugin</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.1.0</version>
   <executions>
     <execution>
       <goals>
@@ -60,18 +73,19 @@ Configure the `pom.xml` file of your Maven project to use DepClean as part of th
 </plugin>
 ```
 
-Or you can run DepClean directly from the command line.
+Or you can run DepClean directly from the command line (the project needs to be compiled first, including its test classes):
 
 ```bash
 cd {PATH_TO_MAVEN_PROJECT}
-mvn compile
-mvn compiler:testCompile
-mvn se.kth.castor:depclean-maven-plugin:2.2.0-SNAPSHOT:depclean
+mvn test-compile
+mvn se.kth.castor:depclean-maven-plugin:2.1.0:depclean
 ```
 
-Let's see an example of running DepClean version 2.0.1 in the project [Apache Commons Numbers](https://github.com/apache/commons-numbers/tree/master/commons-numbers-examples/examples-jmh)!
+The examples above use the latest release published to [Maven Central](https://central.sonatype.com/artifact/se.kth.castor/depclean-maven-plugin). To try the latest snapshot instead, [build from source](#installing-and-building-from-source).
 
-![Demo](https://github.com/castor-software/depclean/blob/master/.img/demo.gif)
+Let's see an example of running DepClean in the project [Apache Commons Numbers](https://github.com/apache/commons-numbers/tree/master/commons-numbers-examples/examples-jmh)!
+
+![Demo](.img/demo.gif)
 
 ## Optional Parameters
 
@@ -82,7 +96,7 @@ The Maven plugin can be configured with the following additional parameters.
 | `<ignoreDependencies>`     | `Set<String>` | A regex expression matching dependencies to be ignored by DepClean during the analysis (i.e., considered as used). This is useful to bypass incomplete result caused by bytecode-level analysis. **For example:** `-DignoreDependencies="net.bytebuddy:byte-buddy:.*","com.google.guava.*"` ignores dependencies with `groupId:artifactId` equals to `net.bytebuddy:byte-buddy` and `groupId` equals to `com.google.guava`. |
 | `<ignoreScopes>`           | `Set<String>` | Add a list of scopes, to be ignored by DepClean during the analysis. Useful to not analyze dependencies with scopes that are not needed at runtime. **Valid scopes are:** `compile`, `provided`, `test`, `runtime`, `system`, `import`. An Empty string indicates no scopes (default).                                                                                                                                      |
 | `<ignoreTests>`            |   `boolean`   | If this is true, DepClean will not analyze the test classes in the project, and, therefore, the dependencies that are only used for testing will be considered unused. This parameter is useful to detect dependencies that have `compile` scope but are only used for testing. **Default value is:** `false`.                                                                                                              |
-| `<createPomDebloated>`     |   `boolean`   | If this is true, DepClean creates a debloated version of the pom without unused dependencies called `debloated-pom.xml`, in the root of the project. **Default value is:** `false`.                                                                                                                                                                                                                                         |
+| `<createPomDebloated>`     |   `boolean`   | If this is true, DepClean creates a debloated version of the pom without unused dependencies called `pom-debloated.xml`, in the root of the project. **Default value is:** `false`.                                                                                                                                                                                                                                         |
 | `<createResultJson>`       |   `boolean`   | If this is true, DepClean creates a JSON file of the dependency tree along with metadata of each dependency. The file is called `depclean-results.json`, and is located in the `target` directory of the project. **Default value is:** `false`.                                                                                                                                                                            |
 | `<createCallGraphCsv>`     |   `boolean`   | If this is true, DepClean creates a CSV file with the static call graph of the API members used in the project. The file is called `depclean-callgraph.csv`, and is located in the `target` directory of the project. **Default value is:** `false`.                                                                                                                                                                        |
 | `<failIfUnusedDirect>`     |   `boolean`   | If this is true, and DepClean reported any unused direct dependency in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                                                                                              |
@@ -98,7 +112,7 @@ For example, if you want to fail the build in the presence of unused direct depe
 <plugin>
   <groupId>se.kth.castor</groupId>
   <artifactId>depclean-maven-plugin</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.1.0</version>
   <executions>
     <execution>
       <goals>
@@ -116,14 +130,14 @@ For example, if you want to fail the build in the presence of unused direct depe
 Of course, it is also possible to execute DepClean with parameters directly from the command line. The previous example can be executed directly as follows:
 
 ```bash
-mvn se.kth.castor:depclean-maven-plugin:2.2.0-SNAPSHOT:depclean -DfailIfUnusedDirect=true -DignoreScopes=provided,test,runtime,system,import
+mvn se.kth.castor:depclean-maven-plugin:2.1.0:depclean -DfailIfUnusedDirect=true -DignoreScopes=provided,test,runtime,system,import
 ```
 
-## How does DepClean works?
+## How does DepClean work?
 
 DepClean runs before executing the `package` phase of the Maven build lifecycle. It statically collects all the types
 referenced in the project under analysis as well as in its declared dependencies. Then, it compares the types that the
-project actually use in the bytecode with respect to the class members belonging to its dependencies.
+project actually uses in the bytecode with respect to the class members belonging to its dependencies.
 
 With this usage information, DepClean constructs a new `pom.xml` based on the following steps:
 
@@ -133,32 +147,57 @@ With this usage information, DepClean constructs a new `pom.xml` based on the fo
 
 If all the tests pass, and the project builds correctly after these changes, then it means that the dependencies identified as bloated can be removed. DepClean produces a file named `pom-debloated.xml`, located in the root of the project, which is a clean version of the original `pom.xml` without bloated dependencies.
 
+## Gradle Plugin
+
+A prototype Gradle plugin providing a `debloat` task for Gradle-based Java projects is available in this repository. It is not yet published to a plugin portal and must be built from source. See the [DepClean Gradle plugin README](depclean-gradle-plugin/README.md) for usage and configuration details.
+
 ## Installing and building from source
 
 Prerequisites:
 
-- [Java OpenJDK 17](https://openjdk.java.net) or above
-- [Apache Maven](https://maven.apache.org/)
+- [Java OpenJDK 21](https://openjdk.java.net) or above (the build targets Java 17 bytecode)
+- No Maven installation needed — the Maven wrapper is included
 
 In a terminal clone the repository and switch to the cloned folder:
 
 ```bash
-git clone https://github.com/castor-software/depclean.git
+git clone https://github.com/ASSERT-KTH/depclean.git
 cd depclean
 ```
 
-Then run the following Maven command to build the application and install the plugin locally:
+Then run the following command to build the application and install the plugin locally:
 
 ```bash
-mvn clean install
+./mvnw clean install
 ```
+
+## Citation
+
+If you use DepClean in academic work, please cite the original paper (see also [CITATION.cff](CITATION.cff)):
+
+```bibtex
+@article{SotoValero2021,
+  title     = {A comprehensive study of bloated dependencies in the {Maven} ecosystem},
+  author    = {Soto-Valero, C{\'e}sar and Harrand, Nicolas and Monperrus, Martin and Baudry, Benoit},
+  journal   = {Empirical Software Engineering},
+  volume    = {26},
+  number    = {3},
+  pages     = {1--44},
+  year      = {2021},
+  doi       = {10.1007/s10664-020-09914-8}
+}
+```
+
+## Contributing
+
+Contributions are welcome! Feel free to open an [issue](https://github.com/ASSERT-KTH/depclean/issues) for bug reports or feature suggestions, or submit a pull request. The [Gradle plugin](depclean-gradle-plugin/README.md) in particular is actively looking for contributors.
 
 ## License
 
-Distributed under the MIT License. See [LICENSE](https://github.com/castor-software/depclean/blob/master/LICENSE.md) for more information.
+Distributed under the MIT License. See [LICENSE](LICENSE.md) for more information.
 
 ## Funding
 
 DepClean is partially funded by the [Wallenberg Autonomous Systems and Software Program (WASP)](https://wasp-sweden.org).
 
-<img src="https://github.com/castor-software/depclean/blob/master/.img/wasp.svg" height="50px" alt="Wallenberg Autonomous Systems and Software Program (WASP)"/>
+<img src=".img/wasp.svg" height="50px" alt="Wallenberg Autonomous Systems and Software Program (WASP)"/>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of DepClean is supported with security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| 2.1.x   | ✅        |
+| < 2.1   | ❌        |
+
+## Reporting a Vulnerability
+
+Please **do not open a public issue** for security vulnerabilities.
+
+Instead, report it privately via [GitHub private vulnerability reporting](https://github.com/ASSERT-KTH/depclean/security/advisories/new). Include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce or a proof of concept
+- The affected version(s)
+
+You will receive a response as soon as possible. Once the issue is confirmed and a fix is available, a security advisory will be published and the fix released.
+
+Note that DepClean is a build-time analysis tool: it does not run in production environments, and it does not modify your source code or original `pom.xml`. Vulnerabilities in DepClean's own dependencies are tracked continuously via Dependabot and SonarCloud.


### PR DESCRIPTION
## Summary

Refreshes the root README for accuracy and completeness.

### Correctness fixes
- **`debloated-pom.xml` → `pom-debloated.xml`** in the parameter table — the code (`MavenDebloater`) actually writes `pom-debloated.xml`, so the table contradicted both the code and the "How does DepClean work?" section.
- **Usage examples now use the released `2.1.0`** instead of `2.2.0-SNAPSHOT`, which users cannot resolve from Maven Central (with a note pointing to build-from-source for snapshots).
- **Links, badges, and clone URL updated** from the old `castor-software` org to `ASSERT-KTH`; images, LICENSE, and CITATION now use relative paths so they survive org/branch renames.
- **Build prerequisites aligned with CI** and the Gradle plugin README: JDK 21+, `./mvnw` (no Maven install needed).

### Polish & additions
- Grammar: "How does DepClean works?" → "work?", "project actually use" → "uses".
- Simplified CLI prep from `mvn compile` + `mvn compiler:testCompile` to `mvn test-compile`.
- Added: table of contents, a Gradle Plugin section linking to `depclean-gradle-plugin/README.md`, a Citation section with BibTeX (matching `CITATION.cff`), and a short Contributing section.

### New files (second commit)
- **`CONTRIBUTING.md`** — build prerequisites (JDK 21, wrappers only), Maven/Gradle build commands including the `publishToMavenLocal` requirement for testing the Gradle plugin against current code, code style (Checkstyle/Spotless), IT golden-file guidance, and the PR checklist.
- **`SECURITY.md`** — private vulnerability reporting via GitHub security advisories, supported versions.
- Both linked from the README Contributing section.

Docs-only change; no code touched.
