### PR TITLE
feat: target Java 8 bytecode so the plugin runs on JDK 8+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [21, 25]
+        java: [25]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     name: Maven Build with Java ${{ matrix.java }} on ${{ matrix.os }}
@@ -41,9 +41,9 @@ jobs:
       - name: "Build and Verify"
         run: ./mvnw -ntp clean verify --errors
 
-        # The following is only executed on Ubuntu on Java 21
+        # The following is only executed on Ubuntu on Java 25
       - name: "Codecov (unit tests)"
-        if: matrix.os == 'ubuntu-latest' && matrix.java == 21 && github.repository == 'ASSERT-KTH/depclean'
+        if: matrix.os == 'ubuntu-latest' && matrix.java == 25 && github.repository == 'ASSERT-KTH/depclean'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
           flags: unittests
 
       - name: "Codecov (integration tests)"
-        if: matrix.os == 'ubuntu-latest' && matrix.java == 21 && github.repository == 'ASSERT-KTH/depclean'
+        if: matrix.os == 'ubuntu-latest' && matrix.java == 25 && github.repository == 'ASSERT-KTH/depclean'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
   # --------------------------------------------------------------------------------------------------------------------
   # For Gradle module
   gradle:
-    name: Gradle build with Java 21 on ubuntu-latest
+    name: Gradle build with Java 25 on ubuntu-latest
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -73,10 +73,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Java 21
+      - name: Set up Java 25
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
-          java-version: 21
+          java-version: 25
           distribution: "temurin"
           cache: "maven"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [21]
+        java: [21, 25]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     name: Maven Build with Java ${{ matrix.java }} on ${{ matrix.os }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
           cache: "maven"
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing! Bug reports, feature suggestions, docu
 
 ## Prerequisites
 
-- Java (Open)JDK 21 or above — the Maven plugin's main sources target Java 8 bytecode (tests target Java 17), but building requires a modern JDK; CI builds with JDK 21
+- Java (Open)JDK 21 or above — the Maven plugin's main sources target Java 8 bytecode (tests target Java 17), but building requires a modern JDK; CI builds with JDK 21 and 25
 - No Maven or Gradle installation needed — both wrappers (`mvnw`, `gradlew`) are included
 
 ## Building the project

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing! Bug reports, feature suggestions, docu
 
 ## Prerequisites
 
-- Java (Open)JDK 21 or above — the Maven plugin's main sources target Java 8 bytecode (tests target Java 17), but building requires a modern JDK; CI builds with JDK 21 and 25
+- Java (Open)JDK 21 or above — the Maven plugin's main sources target Java 8 bytecode (tests target Java 17), but building requires a modern JDK; CI builds with JDK 25
 - No Maven or Gradle installation needed — both wrappers (`mvnw`, `gradlew`) are included
 
 ## Building the project

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing! Bug reports, feature suggestions, docu
 
 ## Prerequisites
 
-- Java (Open)JDK 21 or above — the build targets Java 17 bytecode, but CI builds with JDK 21
+- Java (Open)JDK 21 or above — the Maven plugin's main sources target Java 8 bytecode (tests target Java 17), but building requires a modern JDK; CI builds with JDK 21
 - No Maven or Gradle installation needed — both wrappers (`mvnw`, `gradlew`) are included
 
 ## Building the project

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Importantly, **DepClean does *not* modify your source code or original `pom.xml`
 ### Main Features
 
 * Automatically detects and removes unused dependencies from the `pom.xml`, including those inherited from parent projects.
-* Fully supports Java 21 bytecode analysis, ensuring compatibility with modern Java features.
+* Analyzes bytecode of any Java version, up to the latest release, ensuring compatibility with modern Java features.
 * Runs on Java 8 and above: the plugin ships Java 8 bytecode, so it works on legacy toolchains while still analyzing modern bytecode.
 * Generates a clean and minimal `pom.xml`, free from unused dependencies.
 * Produces detailed, per-dependency usage reports.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Importantly, **DepClean does *not* modify your source code or original `pom.xml`
 
 * Automatically detects and removes unused dependencies from the `pom.xml`, including those inherited from parent projects.
 * Fully supports Java 21 bytecode analysis, ensuring compatibility with modern Java features.
+* Runs on Java 8 and above: the plugin ships Java 8 bytecode, so it works on legacy toolchains while still analyzing modern bytecode.
 * Generates a clean and minimal `pom.xml`, free from unused dependencies.
 * Produces detailed, per-dependency usage reports.
 * Offers fine-grained configuration options to tailor the analysis and cleaning process.
@@ -55,6 +56,8 @@ For a visual overview of how DepClean works and what it can do for your project,
 ["A Comprehensive Study of Bloated Dependencies in the Maven Ecosystem"](http://arxiv.org/pdf/2001.07808) ([DOI: 10.1007/s10664-020-09914-8](https://doi.org/10.1007/s10664-020-09914-8))
 
 ## Usage
+
+DepClean requires Maven 3.9+ and runs on any JVM from Java 8 upwards, regardless of the Java version your project targets.
 
 Configure the `pom.xml` file of your Maven project to use DepClean as part of the build:
 
@@ -155,7 +158,7 @@ A prototype Gradle plugin providing a `debloat` task for Gradle-based Java proje
 
 Prerequisites:
 
-- [Java OpenJDK 21](https://openjdk.java.net) or above (the build targets Java 17 bytecode)
+- [Java OpenJDK 21](https://openjdk.java.net) or above to build (the Maven plugin itself targets Java 8 bytecode and runs on Java 8+)
 - No Maven installation needed — the Maven wrapper is included
 
 In a terminal clone the repository and switch to the cloned folder:

--- a/depclean-core/pom.xml
+++ b/depclean-core/pom.xml
@@ -24,7 +24,6 @@
     <!-- Dependencies -->
     <asm.version>9.10.1</asm.version>
     <guava.version>33.7.1-jre</guava.version>
-    <jgrapht.version>1.5.3</jgrapht.version>
     <plexus-component-annotations.version>2.2.0</plexus-component-annotations.version>
     <plexus-utils.version>4.1.0</plexus-utils.version>
     <qdox.version>2.2.0</qdox.version>
@@ -67,13 +66,6 @@
       <artifactId>maven-core</artifactId>
       <version>${maven-core.version}</version>
       <scope>compile</scope>
-    </dependency>
-
-    <!-- Graph construction and analysis -->
-    <dependency>
-      <groupId>org.jgrapht</groupId>
-      <artifactId>jgrapht-core</artifactId>
-      <version>${jgrapht.version}</version>
     </dependency>
 
     <!-- Utils -->

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/DefaultProjectDependencyAnalyzer.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/DefaultProjectDependencyAnalyzer.java
@@ -33,8 +33,7 @@ import se.kth.depclean.core.model.ProjectContext;
 /** This is principal class that perform the dependency analysis in a Maven project. */
 public class DefaultProjectDependencyAnalyzer {
 
-  private static final Logger log =
-      LoggerFactory.getLogger(DefaultProjectDependencyAnalyzer.class);
+  private static final Logger log = LoggerFactory.getLogger(DefaultProjectDependencyAnalyzer.class);
 
   private final DependencyAnalyzer dependencyAnalyzer = new AsmDependencyAnalyzer();
 

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/DependencyTypes.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/DependencyTypes.java
@@ -32,9 +32,10 @@ public final class DependencyTypes {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof DependencyTypes that)) {
+    if (!(o instanceof DependencyTypes)) {
       return false;
     }
+    DependencyTypes that = (DependencyTypes) o;
     return Objects.equals(allTypes, that.allTypes) && Objects.equals(usedTypes, that.usedTypes);
   }
 

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/ProjectDependencyAnalysisBuilder.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/ProjectDependencyAnalysisBuilder.java
@@ -20,8 +20,7 @@ import se.kth.depclean.core.model.Scope;
 /** Builds the analysis given the declared dependencies and the one actually used. */
 public class ProjectDependencyAnalysisBuilder {
 
-  private static final Logger log =
-      LoggerFactory.getLogger(ProjectDependencyAnalysisBuilder.class);
+  private static final Logger log = LoggerFactory.getLogger(ProjectDependencyAnalysisBuilder.class);
 
   private final ProjectContext context;
   private final ActualUsedClasses actualUsedClasses;

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/ConstantPoolParser.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/ConstantPoolParser.java
@@ -103,39 +103,49 @@ public class ConstantPoolParser {
     for (int ix = 1, num = buf.getChar(); ix < num; ix++) {
       byte tag = buf.get();
       switch (tag) {
-        case CONSTANT_UTF8 -> {
+        case CONSTANT_UTF8:
           stringConstants.put(ix, decodeString(buf));
           continue;
-        }
-        case CONSTANT_CLASS, CONSTANT_STRING, CONSTANT_METHOD_TYPE ->
-            classes.add((int) buf.getChar());
-        case CONSTANT_FIELDREF,
-            CONSTANT_METHODREF,
-            CONSTANT_INTERFACEMETHODREF,
-            CONSTANT_NAME_AND_TYPE -> {
+        case CONSTANT_CLASS:
+        case CONSTANT_STRING:
+        case CONSTANT_METHOD_TYPE:
+          classes.add((int) buf.getChar());
+          break;
+        case CONSTANT_FIELDREF:
+        case CONSTANT_METHODREF:
+        case CONSTANT_INTERFACEMETHODREF:
+        case CONSTANT_NAME_AND_TYPE:
           buf.getChar();
           buf.getChar();
-        }
-        case CONSTANT_INTEGER -> buf.getInt();
-        case CONSTANT_FLOAT -> buf.getFloat();
-        case CONSTANT_DOUBLE -> {
+          break;
+        case CONSTANT_INTEGER:
+          buf.getInt();
+          break;
+        case CONSTANT_FLOAT:
+          buf.getFloat();
+          break;
+        case CONSTANT_DOUBLE:
           buf.getDouble();
           ix++;
-        }
-        case CONSTANT_LONG -> {
+          break;
+        case CONSTANT_LONG:
           buf.getLong();
           ix++;
-        }
-        case CONSTANT_METHODHANDLE -> {
+          break;
+        case CONSTANT_METHODHANDLE:
           buf.get();
           buf.getChar();
-        }
-        case CONSTANT_INVOKE_DYNAMIC -> {
+          break;
+        case CONSTANT_INVOKE_DYNAMIC:
           buf.getChar();
           buf.getChar();
-        }
-        case CONSTANT_MODULE, CONSTANT_PACKAGE -> buf.getChar();
-        default -> throw new RuntimeException("Unknown constant pool type '" + tag + "'");
+          break;
+        case CONSTANT_MODULE:
+        case CONSTANT_PACKAGE:
+          buf.getChar();
+          break;
+        default:
+          throw new RuntimeException("Unknown constant pool type '" + tag + "'");
       }
     }
     Set<String> result = new HashSet<>();

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DefaultAnnotationVisitor.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DefaultAnnotationVisitor.java
@@ -40,8 +40,8 @@ public class DefaultAnnotationVisitor extends AnnotationVisitor {
 
   @Override
   public void visit(@Nullable final String name, @Nullable final Object value) {
-    if (value instanceof Type type) {
-      resultCollector.addType(type);
+    if (value instanceof Type) {
+      resultCollector.addType((Type) value);
     }
   }
 

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DefaultClassVisitor.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DefaultClassVisitor.java
@@ -106,8 +106,8 @@ public class DefaultClassVisitor extends ClassVisitor {
     } else {
       addTypeSignature(signature);
     }
-    if (value instanceof Type type) {
-      resultCollector.addType(type);
+    if (value instanceof Type) {
+      resultCollector.addType((Type) value);
     }
     return fieldVisitor;
   }

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DefaultMethodVisitor.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DefaultMethodVisitor.java
@@ -100,8 +100,8 @@ public class DefaultMethodVisitor extends MethodVisitor {
 
   @Override
   public void visitLdcInsn(final Object cst) {
-    if (cst instanceof Type type) {
-      resultCollector.addType(type);
+    if (cst instanceof Type) {
+      resultCollector.addType((Type) cst);
     }
   }
 

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/ResultCollector.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/ResultCollector.java
@@ -45,11 +45,15 @@ public class ResultCollector {
 
   void addType(@NonNull final Type t) {
     switch (t.getSort()) {
-      case Type.ARRAY -> addType(t.getElementType());
-      case Type.OBJECT -> addName(t.getClassName().replace('.', '/'));
-      default -> {
+      case Type.ARRAY:
+        addType(t.getElementType());
+        break;
+      case Type.OBJECT:
+        addName(t.getClassName().replace('.', '/'));
+        break;
+      default:
         // no-op
-      }
+        break;
     }
   }
 

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
@@ -116,8 +116,7 @@ public class DefaultCallGraph {
 
   /** Clears all shared static state so that consecutive analyses start from a clean graph. */
   public static void clear() {
-    // The vertex set is copied because removeAllVertices cannot iterate the set it is mutating.
-    directedGraph.removeAllVertices(new HashSet<>(directedGraph.vertexSet()));
+    adjacencyList.clear();
     projectVertices.clear();
     usagesPerClass.clear();
   }

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
@@ -17,15 +17,13 @@
 
 package se.kth.depclean.core.analysis.graph;
 
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import org.jgrapht.graph.AbstractBaseGraph;
-import org.jgrapht.graph.DefaultDirectedGraph;
-import org.jgrapht.graph.DefaultEdge;
-import org.jgrapht.traverse.DepthFirstIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,8 +35,7 @@ public class DefaultCallGraph {
 
   private static final Logger log = LoggerFactory.getLogger(DefaultCallGraph.class);
 
-  private static final AbstractBaseGraph<String, DefaultEdge> directedGraph =
-      new DefaultDirectedGraph<>(DefaultEdge.class);
+  private static final Map<String, Set<String>> adjacencyList = new HashMap<>();
   private static final Set<String> projectVertices = new HashSet<>();
   private static final Map<String, Set<String>> usagesPerClass = new HashMap<>();
 
@@ -49,12 +46,10 @@ public class DefaultCallGraph {
    * @param referencedClassMembers The target.
    */
   public static void addEdge(String clazz, Set<String> referencedClassMembers) {
-    directedGraph.addVertex(clazz);
+    Set<String> neighbors = adjacencyList.computeIfAbsent(clazz, k -> new HashSet<>());
     for (String referencedClassMember : referencedClassMembers) {
-      if (!directedGraph.containsVertex(referencedClassMember)) {
-        directedGraph.addVertex(referencedClassMember);
-      }
-      directedGraph.addEdge(clazz, referencedClassMember);
+      adjacencyList.computeIfAbsent(referencedClassMember, k -> new HashSet<>());
+      neighbors.add(referencedClassMember);
       projectVertices.add(clazz);
 
       // Save the pair [class -> referencedClassMember] for further analysis
@@ -86,12 +81,20 @@ public class DefaultCallGraph {
    * @return The set of all visited vertices.
    */
   private static Set<String> traverse(String start) {
-    Set<String> referencedClassMembers = new HashSet<>();
-    Iterator<String> iterator = new DepthFirstIterator<>(directedGraph, start);
-    while (iterator.hasNext()) {
-      referencedClassMembers.add(iterator.next());
+    Set<String> visited = new HashSet<>();
+    Deque<String> stack = new ArrayDeque<>();
+    stack.push(start);
+    while (!stack.isEmpty()) {
+      String current = stack.pop();
+      if (visited.add(current)) {
+        for (String neighbor : adjacencyList.getOrDefault(current, Collections.emptySet())) {
+          if (!visited.contains(neighbor)) {
+            stack.push(neighbor);
+          }
+        }
+      }
     }
-    return referencedClassMembers;
+    return visited;
   }
 
   private static void addReferencedClassMember(String clazz, String referencedClassMember) {
@@ -99,8 +102,12 @@ public class DefaultCallGraph {
     s.add(referencedClassMember);
   }
 
-  public static AbstractBaseGraph<String, DefaultEdge> getDirectedGraph() {
-    return directedGraph;
+  public static boolean containsVertex(String vertex) {
+    return adjacencyList.containsKey(vertex);
+  }
+
+  public static boolean containsEdge(String from, String to) {
+    return adjacencyList.getOrDefault(from, Collections.emptySet()).contains(to);
   }
 
   public static Set<String> getProjectVertices() {

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/DependencyAnalysisInfo.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/DependencyAnalysisInfo.java
@@ -1,11 +1,85 @@
 package se.kth.depclean.core.analysis.model;
 
+import java.util.Objects;
 import java.util.SortedSet;
+import org.jspecify.annotations.Nullable;
 
 /** The result of a dependency analysis. */
-public record DependencyAnalysisInfo(
-    String status,
-    String type,
-    Long size,
-    SortedSet<String> allTypes,
-    SortedSet<String> usedTypes) {}
+public final class DependencyAnalysisInfo {
+
+  private final String status;
+  private final String type;
+  private final Long size;
+  private final SortedSet<String> allTypes;
+  private final SortedSet<String> usedTypes;
+
+  /** Creates the analysis info for a dependency. */
+  public DependencyAnalysisInfo(
+      String status,
+      String type,
+      Long size,
+      SortedSet<String> allTypes,
+      SortedSet<String> usedTypes) {
+    this.status = status;
+    this.type = type;
+    this.size = size;
+    this.allTypes = allTypes;
+    this.usedTypes = usedTypes;
+  }
+
+  public String status() {
+    return status;
+  }
+
+  public String type() {
+    return type;
+  }
+
+  public Long size() {
+    return size;
+  }
+
+  public SortedSet<String> allTypes() {
+    return allTypes;
+  }
+
+  public SortedSet<String> usedTypes() {
+    return usedTypes;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DependencyAnalysisInfo)) {
+      return false;
+    }
+    DependencyAnalysisInfo that = (DependencyAnalysisInfo) o;
+    return Objects.equals(status, that.status)
+        && Objects.equals(type, that.type)
+        && Objects.equals(size, that.size)
+        && Objects.equals(allTypes, that.allTypes)
+        && Objects.equals(usedTypes, that.usedTypes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(status, type, size, allTypes, usedTypes);
+  }
+
+  @Override
+  public String toString() {
+    return "DependencyAnalysisInfo[status="
+        + status
+        + ", type="
+        + type
+        + ", size="
+        + size
+        + ", allTypes="
+        + allTypes
+        + ", usedTypes="
+        + usedTypes
+        + "]";
+  }
+}

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/ProjectDependencyAnalysis.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/ProjectDependencyAnalysis.java
@@ -323,9 +323,10 @@ public final class ProjectDependencyAnalysis {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ProjectDependencyAnalysis that)) {
+    if (!(o instanceof ProjectDependencyAnalysis)) {
       return false;
     }
+    ProjectDependencyAnalysis that = (ProjectDependencyAnalysis) o;
     return Objects.equals(usedDirectDependencies, that.usedDirectDependencies)
         && Objects.equals(usedTransitiveDependencies, that.usedTransitiveDependencies)
         && Objects.equals(usedInheritedDirectDependencies, that.usedInheritedDirectDependencies)
@@ -333,8 +334,7 @@ public final class ProjectDependencyAnalysis {
             usedInheritedTransitiveDependencies, that.usedInheritedTransitiveDependencies)
         && Objects.equals(unusedDirectDependencies, that.unusedDirectDependencies)
         && Objects.equals(unusedTransitiveDependencies, that.unusedTransitiveDependencies)
-        && Objects.equals(
-            unusedInheritedDirectDependencies, that.unusedInheritedDirectDependencies)
+        && Objects.equals(unusedInheritedDirectDependencies, that.unusedInheritedDirectDependencies)
         && Objects.equals(
             unusedInheritedTransitiveDependencies, that.unusedInheritedTransitiveDependencies)
         && Objects.equals(ignoredDependencies, that.ignoredDependencies)

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/src/ImportsAnalyzer.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/src/ImportsAnalyzer.java
@@ -75,9 +75,10 @@ public final class ImportsAnalyzer {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ImportsAnalyzer that)) {
+    if (!(o instanceof ImportsAnalyzer)) {
       return false;
     }
+    ImportsAnalyzer that = (ImportsAnalyzer) o;
     return Objects.equals(directoryPath, that.directoryPath);
   }
 

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/src/XmlClassesAnalyzer.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/src/XmlClassesAnalyzer.java
@@ -29,20 +29,24 @@ import org.xml.sax.helpers.DefaultHandler;
 
 /**
  * Collects fully qualified class names referenced in XML resource files, such as Spring XML
- * configurations ({@code <bean class="..."/>}), web deployment descriptors ({@code
- * <filter-class>}, {@code <servlet-class>}, {@code <listener-class>}), persistence configurations,
- * logging configurations, etc.
+ * configurations ({@code <bean class="..."/>}), web deployment descriptors ({@code <filter-class>},
+ * {@code <servlet-class>}, {@code <listener-class>}), persistence configurations, logging
+ * configurations, etc.
  *
  * <p>Rather than understanding each XML dialect, this analyzer harvests every attribute value and
- * element text node that looks like a fully qualified class name. False positives are harmless:
- * the analysis only considers harvested names that actually resolve to a class of a known
- * dependency.
- *
- * @param directoryPath a directory with XML resource files
+ * element text node that looks like a fully qualified class name. False positives are harmless: the
+ * analysis only considers harvested names that actually resolve to a class of a known dependency.
  */
-public record XmlClassesAnalyzer(Path directoryPath) {
+public final class XmlClassesAnalyzer {
 
   private static final Logger log = LoggerFactory.getLogger(XmlClassesAnalyzer.class);
+
+  /** A directory with XML resource files. */
+  private final Path directoryPath;
+
+  public XmlClassesAnalyzer(Path directoryPath) {
+    this.directoryPath = directoryPath;
+  }
 
   /**
    * A dotted identifier with at least two segments (e.g. {@code org.example.Foo}). Possessive
@@ -99,8 +103,7 @@ public record XmlClassesAnalyzer(Path directoryPath) {
    * never resolved. DOCTYPE declarations themselves remain allowed since legacy descriptors (e.g.
    * Servlet 2.3 web.xml or old Spring beans files) legitimately declare them.
    */
-  private static SAXParser newSecureSaxParser()
-      throws ParserConfigurationException, SAXException {
+  private static SAXParser newSecureSaxParser() throws ParserConfigurationException, SAXException {
     SAXParserFactory factory = SAXParserFactory.newInstance();
     factory.setNamespaceAware(true);
     factory.setXIncludeAware(false);

--- a/depclean-core/src/main/java/se/kth/depclean/core/model/ClassName.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/ClassName.java
@@ -30,9 +30,10 @@ public final class ClassName implements Comparable<ClassName> {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ClassName className)) {
+    if (!(o instanceof ClassName)) {
       return false;
     }
+    ClassName className = (ClassName) o;
     return Objects.equals(value, className.value);
   }
 

--- a/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
@@ -204,9 +204,10 @@ public class Dependency {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof Dependency that)) {
+    if (!(o instanceof Dependency)) {
       return false;
     }
+    Dependency that = (Dependency) o;
     return Objects.equals(groupId, that.groupId)
         && Objects.equals(dependencyId, that.dependencyId)
         && Objects.equals(version, that.version)

--- a/depclean-core/src/main/java/se/kth/depclean/core/model/Scope.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/Scope.java
@@ -1,5 +1,40 @@
 package se.kth.depclean.core.model;
 
-/** Represents a dependency scope. */
-public record Scope(String value) {}
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
+/** Represents a dependency scope. */
+public final class Scope {
+
+  private final String value;
+
+  public Scope(String value) {
+    this.value = value;
+  }
+
+  public String value() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Scope)) {
+      return false;
+    }
+    Scope scope = (Scope) o;
+    return Objects.equals(value, scope.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
+  }
+
+  @Override
+  public String toString() {
+    return "Scope[value=" + value + "]";
+  }
+}

--- a/depclean-core/src/main/java/se/kth/depclean/core/wrapper/DependencyManagerWrapper.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/wrapper/DependencyManagerWrapper.java
@@ -101,8 +101,8 @@ public interface DependencyManagerWrapper {
   Set<Path> getResourcesDirectories();
 
   /**
-   * Directories containing the project's test resource files, e.g. {@code src/test/resources}.
-   * The returned directories may not exist.
+   * Directories containing the project's test resource files, e.g. {@code src/test/resources}. The
+   * returned directories may not exist.
    *
    * @return the test resource directories
    */

--- a/depclean-core/src/test/java/se/kth/depclean/core/analysis/ClassFileVisitorUtilsTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/analysis/ClassFileVisitorUtilsTest.java
@@ -1,10 +1,9 @@
 package se.kth.depclean.core.analysis;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class ClassFileVisitorUtilsTest {
 

--- a/depclean-core/src/test/java/se/kth/depclean/core/analysis/graph/DefaultCallGraphTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/analysis/graph/DefaultCallGraphTest.java
@@ -3,8 +3,6 @@ package se.kth.depclean.core.analysis.graph;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.jgrapht.graph.AbstractBaseGraph;
-import org.jgrapht.graph.DefaultEdge;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,14 +44,13 @@ class DefaultCallGraphTest {
 
   @Test
   void clearShouldResetDirectedGraphState() {
-    AbstractBaseGraph<String, DefaultEdge> directedGraph = DefaultCallGraph.getDirectedGraph();
-    Assertions.assertFalse(directedGraph.vertexSet().isEmpty());
-    Assertions.assertFalse(directedGraph.edgeSet().isEmpty());
+    Assertions.assertTrue(DefaultCallGraph.containsVertex("A"));
+    Assertions.assertTrue(DefaultCallGraph.containsEdge("A", "B"));
 
     DefaultCallGraph.clear();
 
-    Assertions.assertTrue(directedGraph.vertexSet().isEmpty());
-    Assertions.assertTrue(directedGraph.edgeSet().isEmpty());
+    Assertions.assertFalse(DefaultCallGraph.containsVertex("A"));
+    Assertions.assertFalse(DefaultCallGraph.containsEdge("A", "B"));
   }
 
   @AfterEach

--- a/depclean-core/src/test/java/se/kth/depclean/core/analysis/graphTest/DependencyClassFileVisitorTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/analysis/graphTest/DependencyClassFileVisitorTest.java
@@ -3,8 +3,6 @@ package se.kth.depclean.core.analysis.graphTest;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import org.jgrapht.graph.AbstractBaseGraph;
-import org.jgrapht.graph.DefaultEdge;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,15 +25,14 @@ class DependencyClassFileVisitorTest {
 
     ResultCollector resultCollector = new ResultCollector();
     FileInputStream fileInputStream = new FileInputStream(classFile);
-    AbstractBaseGraph<String, DefaultEdge> directedGraph = DefaultCallGraph.getDirectedGraph();
 
     DependencyClassFileVisitor visitor = new DependencyClassFileVisitor();
     visitor.visitClass(className, fileInputStream);
 
     // Checking for the expected results.
-    Assertions.assertTrue(directedGraph.containsVertex(className));
+    Assertions.assertTrue(DefaultCallGraph.containsVertex(className));
     for (String referencedClassMember : resultCollector.getDependencies()) {
-      Assertions.assertTrue(directedGraph.containsEdge(className, referencedClassMember));
+      Assertions.assertTrue(DefaultCallGraph.containsEdge(className, referencedClassMember));
     }
 
     // Confirming the successful termination of DependencyClassFileVisitor object.

--- a/depclean-core/src/test/java/se/kth/depclean/core/analysis/src/XmlClassesAnalyzerTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/analysis/src/XmlClassesAnalyzerTest.java
@@ -113,8 +113,7 @@ class XmlClassesAnalyzerTest {
     write("a/b/c/deep.xml", "<conf><handler>org.example.deep.DeepHandler</handler></conf>");
     write("top.xml", "<conf handler=\"org.example.top.TopHandler\"/>");
 
-    assertThat(collect())
-        .contains("org.example.deep.DeepHandler", "org.example.top.TopHandler");
+    assertThat(collect()).contains("org.example.deep.DeepHandler", "org.example.top.TopHandler");
   }
 
   @Test

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/graph/MavenDependencyGraph.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/graph/MavenDependencyGraph.java
@@ -238,7 +238,8 @@ public class MavenDependencyGraph implements DependencyGraph {
       return value == null ? "" : value;
     }
     Matcher matcher = PROPERTY_PATTERN.matcher(value);
-    StringBuilder result = new StringBuilder();
+    // StringBuffer overload: Matcher.appendReplacement(StringBuilder, ...) is Java 9+
+    StringBuffer result = new StringBuffer();
     while (matcher.find()) {
       String resolved = resolveProperty(matcher.group(1));
       matcher.appendReplacement(
@@ -249,12 +250,19 @@ public class MavenDependencyGraph implements DependencyGraph {
   }
 
   private String resolveProperty(String key) {
-    return switch (key) {
-      case "project.groupId", "pom.groupId" -> project.getGroupId();
-      case "project.artifactId", "pom.artifactId" -> project.getArtifactId();
-      case "project.version", "pom.version" -> project.getVersion();
-      default -> project.getProperties().getProperty(key);
-    };
+    switch (key) {
+      case "project.groupId":
+      case "pom.groupId":
+        return project.getGroupId();
+      case "project.artifactId":
+      case "pom.artifactId":
+        return project.getArtifactId();
+      case "project.version":
+      case "pom.version":
+        return project.getVersion();
+      default:
+        return project.getProperties().getProperty(key);
+    }
   }
 
   private ImmutableSet<Dependency> getAllDependencies(MavenProject project) {
@@ -266,7 +274,8 @@ public class MavenDependencyGraph implements DependencyGraph {
   private ImmutableSet<Dependency> getDirectDependencies(Model model) {
     return model.getDependencies().stream()
         .map(this::findDepCleanDependency)
-        .flatMap(Optional::stream)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
         .collect(toImmutableSet());
   }
 }

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenInvoker.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenInvoker.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -68,9 +69,9 @@ public final class MavenInvoker {
    * @throws InterruptedException If the current thread is interrupted while waiting for the
    *     command.
    * @deprecated use {@link #runCommand(List, File)} instead, which supports arguments containing
-   *     spaces.
+   *     spaces. Deprecated since 2.2.0.
    */
-  @Deprecated(since = "2.2.0")
+  @Deprecated
   public static String[] runCommand(String cmd, @Nullable File directory)
       throws IOException, InterruptedException {
     // The same tokenization Runtime.exec(String) used to apply to this command.
@@ -181,7 +182,7 @@ public final class MavenInvoker {
     }
     // On Windows `mvn` is a batch script, which cannot be started by CreateProcess directly, so it
     // has to be launched through the command interpreter, as it was before as well.
-    List<String> windowsCommand = new ArrayList<>(List.of("cmd", "/c"));
+    List<String> windowsCommand = new ArrayList<>(Arrays.asList("cmd", "/c"));
     windowsCommand.addAll(command);
     return windowsCommand;
   }
@@ -251,25 +252,20 @@ public final class MavenInvoker {
       if (!process.isAlive()) {
         return;
       }
-      // Snapshot the descendants now: once the process is destroyed they can no longer be listed
-      // through it, but the handles keep working.
-      List<ProcessHandle> tree = new ArrayList<>(process.descendants().toList());
-      tree.add(process.toHandle());
-
-      tree.forEach(ProcessHandle::destroy);
-      if (awaitProcesses(tree, deadlineNanos)) {
+      // Java 8 has no ProcessHandle, so only the process itself can be terminated: its
+      // descendants cannot be enumerated. Child processes are expected to end with their parent.
+      process.destroy();
+      if (awaitProcess(process, deadlineNanos)) {
         return;
       }
-      // The graceful termination did not work in time. Kill the whole tree, and always allow a
+      // The graceful termination did not work in time. Kill the process, and always allow a
       // short extra window for the operating system to reap it, even if the budget is spent.
-      tree.forEach(ProcessHandle::destroyForcibly);
+      process.destroyForcibly();
       long killDeadlineNanos =
           Math.max(deadlineNanos, System.nanoTime())
               + TimeUnit.MILLISECONDS.toNanos(FORCIBLE_KILL_GRACE_MILLIS);
-      if (!awaitProcesses(tree, killDeadlineNanos)) {
-        log.warn(
-            "The process of the command, or one of its child processes, did not end and had to "
-                + "be abandoned");
+      if (!awaitProcess(process, killDeadlineNanos)) {
+        log.warn("The process of the command did not end and had to be abandoned");
       }
     }
 
@@ -285,26 +281,15 @@ public final class MavenInvoker {
       awaitThread(reader);
     }
 
-    /** Waits until all the process handles have ended or the deadline is reached. */
-    private boolean awaitProcesses(List<ProcessHandle> handles, long untilNanos) {
-      boolean allDead = true;
-      for (ProcessHandle handle : handles) {
-        allDead &= awaitProcess(handle, untilNanos);
-      }
-      return allDead;
-    }
-
     /** Waits for the process, and reports whether it ended. */
-    private boolean awaitProcess(ProcessHandle handle, long untilNanos) {
-      while (handle.isAlive()) {
+    private boolean awaitProcess(Process process, long untilNanos) {
+      while (process.isAlive()) {
         long remainingMillis = TimeUnit.NANOSECONDS.toMillis(untilNanos - System.nanoTime());
         if (remainingMillis <= 0) {
-          return !handle.isAlive();
+          return !process.isAlive();
         }
         try {
-          // ProcessHandle has no timed wait, so poll it until the deadline, briefly enough to not
-          // overshoot it.
-          Thread.sleep(Math.min(remainingMillis, 50));
+          process.waitFor(remainingMillis, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
           interrupted = true;
         }

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenInvoker.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenInvoker.java
@@ -23,16 +23,19 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -252,20 +255,27 @@ public final class MavenInvoker {
       if (!process.isAlive()) {
         return;
       }
-      // Java 8 has no ProcessHandle, so only the process itself can be terminated: its
-      // descendants cannot be enumerated. Child processes are expected to end with their parent.
+      // Snapshot the descendants now: once the process is destroyed they can no longer be listed
+      // through it, but the handles keep working. Empty on a Java 8 runtime, where descendants
+      // cannot be enumerated and children are expected to end with their parent.
+      List<Object> tree = ProcessHandles.treeOf(process);
+
+      ProcessHandles.destroy(tree, false);
       process.destroy();
-      if (awaitProcess(process, deadlineNanos)) {
+      if (awaitProcess(process, deadlineNanos) && awaitHandles(tree, deadlineNanos)) {
         return;
       }
-      // The graceful termination did not work in time. Kill the process, and always allow a
+      // The graceful termination did not work in time. Kill the whole tree, and always allow a
       // short extra window for the operating system to reap it, even if the budget is spent.
+      ProcessHandles.destroy(tree, true);
       process.destroyForcibly();
       long killDeadlineNanos =
           Math.max(deadlineNanos, System.nanoTime())
               + TimeUnit.MILLISECONDS.toNanos(FORCIBLE_KILL_GRACE_MILLIS);
-      if (!awaitProcess(process, killDeadlineNanos)) {
-        log.warn("The process of the command did not end and had to be abandoned");
+      if (!(awaitProcess(process, killDeadlineNanos) && awaitHandles(tree, killDeadlineNanos))) {
+        log.warn(
+            "The process of the command, or one of its child processes, did not end and had to "
+                + "be abandoned");
       }
     }
 
@@ -297,6 +307,33 @@ public final class MavenInvoker {
       return true;
     }
 
+    /** Waits until all the process handles have ended or the deadline is reached. */
+    private boolean awaitHandles(List<Object> handles, long untilNanos) {
+      boolean allDead = true;
+      for (Object handle : handles) {
+        allDead &= awaitHandle(handle, untilNanos);
+      }
+      return allDead;
+    }
+
+    /** Waits for the process handle, and reports whether it ended. */
+    private boolean awaitHandle(Object handle, long untilNanos) {
+      while (ProcessHandles.isAlive(handle)) {
+        long remainingMillis = TimeUnit.NANOSECONDS.toMillis(untilNanos - System.nanoTime());
+        if (remainingMillis <= 0) {
+          return !ProcessHandles.isAlive(handle);
+        }
+        try {
+          // ProcessHandle has no timed wait, so poll it until the deadline, briefly enough to not
+          // overshoot it.
+          Thread.sleep(Math.min(remainingMillis, 50));
+        } catch (InterruptedException e) {
+          interrupted = true;
+        }
+      }
+      return true;
+    }
+
     /** Waits for the thread, and reports whether it ended. */
     private boolean awaitThread(Thread thread) {
       while (thread.isAlive()) {
@@ -315,6 +352,89 @@ public final class MavenInvoker {
 
     private long remainingMillis() {
       return TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+    }
+  }
+
+  /**
+   * Reflective access to {@code ProcessHandle}, which only exists on Java 9+. The bytecode of this
+   * class targets Java 8, but on the Java 9+ runtimes it actually runs on, the descendants of a
+   * process can still be terminated: without this, killing a command wrapped in an interpreter
+   * (e.g. {@code cmd /c} on Windows) would leave the actual process running. On a Java 8 runtime
+   * every method is a no-op.
+   */
+  private static final class ProcessHandles {
+
+    private static final @Nullable Method TO_HANDLE;
+    private static final @Nullable Method DESCENDANTS;
+    private static final @Nullable Method DESTROY;
+    private static final @Nullable Method DESTROY_FORCIBLY;
+    private static final @Nullable Method IS_ALIVE;
+
+    static {
+      Method toHandle = null;
+      Method descendants = null;
+      Method destroy = null;
+      Method destroyForcibly = null;
+      Method isAlive = null;
+      try {
+        Class<?> processHandle = Class.forName("java.lang.ProcessHandle");
+        toHandle = Process.class.getMethod("toHandle");
+        descendants = processHandle.getMethod("descendants");
+        destroy = processHandle.getMethod("destroy");
+        destroyForcibly = processHandle.getMethod("destroyForcibly");
+        isAlive = processHandle.getMethod("isAlive");
+      } catch (ReflectiveOperationException e) {
+        // Java 8 runtime: ProcessHandle is not available
+      }
+      TO_HANDLE = toHandle;
+      DESCENDANTS = descendants;
+      DESTROY = destroy;
+      DESTROY_FORCIBLY = destroyForcibly;
+      IS_ALIVE = isAlive;
+    }
+
+    private ProcessHandles() {}
+
+    /** The handles of the descendants of the process and of the process itself. */
+    private static List<Object> treeOf(Process process) {
+      if (TO_HANDLE == null || DESCENDANTS == null) {
+        return Collections.emptyList();
+      }
+      try {
+        Object handle = TO_HANDLE.invoke(process);
+        List<Object> tree = new ArrayList<>();
+        ((Stream<?>) DESCENDANTS.invoke(handle)).forEach(tree::add);
+        tree.add(handle);
+        return tree;
+      } catch (ReflectiveOperationException | RuntimeException e) {
+        log.debug("Unable to list the process tree: {}", e.getMessage());
+        return Collections.emptyList();
+      }
+    }
+
+    private static void destroy(List<Object> handles, boolean forcibly) {
+      Method method = forcibly ? DESTROY_FORCIBLY : DESTROY;
+      if (method == null) {
+        return;
+      }
+      for (Object handle : handles) {
+        try {
+          method.invoke(handle);
+        } catch (ReflectiveOperationException | RuntimeException e) {
+          log.debug("Unable to terminate a process of the tree: {}", e.getMessage());
+        }
+      }
+    }
+
+    private static boolean isAlive(Object handle) {
+      if (IS_ALIVE == null) {
+        return false;
+      }
+      try {
+        return Boolean.TRUE.equals(IS_ALIVE.invoke(handle));
+      } catch (ReflectiveOperationException | RuntimeException e) {
+        return false;
+      }
     }
   }
 

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
@@ -3,13 +3,16 @@ package se.kth.depclean.wrapper;
 import com.google.common.collect.ImmutableSet;
 import fr.dutra.tools.maven.deptree.core.ParseException;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -127,12 +130,12 @@ public class MavenDependencyManager implements DependencyManagerWrapper {
 
   @Override
   public Set<Path> getOutputDirectories() {
-    return Set.of(Paths.get(project.getBuild().getOutputDirectory()));
+    return Collections.singleton(Paths.get(project.getBuild().getOutputDirectory()));
   }
 
   @Override
   public Set<Path> getTestOutputDirectories() {
-    return Set.of(Paths.get(project.getBuild().getTestOutputDirectory()));
+    return Collections.singleton(Paths.get(project.getBuild().getTestOutputDirectory()));
   }
 
   private Model buildModel(MavenProject project) {
@@ -140,10 +143,10 @@ public class MavenDependencyManager implements DependencyManagerWrapper {
 
     /* Build Maven model to manipulate the pom */
     final Model model;
-    FileReader reader;
+    Reader reader;
     MavenXpp3Reader mavenReader = new MavenXpp3Reader();
     try {
-      reader = new FileReader(pomFile, StandardCharsets.UTF_8);
+      reader = new InputStreamReader(new FileInputStream(pomFile), StandardCharsets.UTF_8);
       model = mavenReader.read(reader);
       model.setPomFile(pomFile);
     } catch (Exception ex) {

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
@@ -14,7 +14,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -268,7 +267,8 @@ public class MavenDependencyManager implements DependencyManagerWrapper {
   @Override
   public void generateDependencyTree(File treeFile) throws IOException, InterruptedException {
     MavenInvoker.runCommand(
-        List.of("mvn", "dependency:tree", "-DoutputFile=" + treeFile, "-Dverbose=true"), null);
+        Arrays.asList("mvn", "dependency:tree", "-DoutputFile=" + treeFile, "-Dverbose=true"),
+        null);
   }
 
   @Override

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
@@ -225,8 +225,8 @@ public class MavenDependencyManager implements DependencyManagerWrapper {
   }
 
   /**
-   * The webapp source directory (containing web.xml), honoring a custom {@code
-   * warSourceDirectory} configured on the maven-war-plugin.
+   * The webapp source directory (containing web.xml), honoring a custom {@code warSourceDirectory}
+   * configured on the maven-war-plugin.
    */
   private Path getWebappDirectory() {
     String warSourceDirectory =

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
@@ -268,8 +268,7 @@ public class DepCleanMojoIT {
               "target/maven-it/se/kth/depclean/DepCleanMojoIT/json_should_be_correct"
                   + "/project/target/depclean-results.json");
       assertThat(result).isSuccessful();
-      String actualJsonContent =
-          FileUtils.readFileToString(actualJsonFile, StandardCharsets.UTF_8);
+      String actualJsonContent = FileUtils.readFileToString(actualJsonFile, StandardCharsets.UTF_8);
       // Jar sizes vary with the JDK that built them, so compare with sizes masked
       Assertions.assertEquals(maskSizes(expectedJsonContent), maskSizes(actualJsonContent));
     }

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/graph/MavenDependencyGraphTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/graph/MavenDependencyGraphTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/util/MavenInvokerTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/util/MavenInvokerTest.java
@@ -206,7 +206,7 @@ class MavenInvokerTest {
         // The end of the output is the interesting part and has to be kept, the beginning is
         // dropped.
         .hasMessageContaining("error line " + (lines - 1))
-        .matches(t -> !t.getMessage().contains("error line 0" + System.lineSeparator()));
+        .hasMessageNotContaining("error line 0" + System.lineSeparator());
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
+    <extra-enforcer-rules.version>1.10.0</extra-enforcer-rules.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
     <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
@@ -53,7 +54,10 @@
     <spotless-maven-plugin.version>3.10.0</spotless-maven-plugin.version>
 
     <!-- Build settings -->
-    <java.version>17</java.version>
+    <!-- Main sources target Java 8 bytecode so the plugin runs on Maven with JDK 8+;
+         tests compile and run on the modern build JDK. -->
+    <java.version>8</java.version>
+    <java.test.version>17</java.test.version>
     <linkXRef>false</linkXRef>
     <project.build.outputTimestamp>2026-08-22T00:00:00Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -130,12 +134,26 @@
                 <requireJavaVersion>
                   <version>[17,)</version>
                 </requireJavaVersion>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.8</maxJdkVersion>
+                  <ignoredScopes>
+                    <ignoredScope>test</ignoredScope>
+                    <ignoredScope>provided</ignoredScope>
+                  </ignoredScopes>
+                </enforceBytecodeVersion>
                 <banDuplicatePomDependencyVersions></banDuplicatePomDependencyVersions>
                 <reactorModuleConvergence></reactorModuleConvergence>
               </rules>
             </configuration>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>${extra-enforcer-rules.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <!-- Maven compiler plugin -->
@@ -145,6 +163,7 @@
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
           <release>${java.version}</release>
+          <testRelease>${java.test.version}</testRelease>
           <fork>true</fork>
           <executable>${JAVA_HOME}/bin/javac</executable>
           <compilerArgs>
@@ -159,6 +178,8 @@
             <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
             <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
             <arg>-parameters</arg>
+            <!-- Targeting Java 8 is obsolete on modern JDKs; silence the warning -->
+            <arg>-Xlint:-options</arg>
             <arg>--should-stop=ifError=FLOW</arg>
             <arg>-XDcompilePolicy=simple</arg>
             <!-- Required by Error Prone 2.50+ on JDK 21 -->


### PR DESCRIPTION
## What

Restores the ability to run DepClean on Maven with **JDK 8+** by compiling the main sources of `depclean-core` and `depclean-maven-plugin` with `--release 8`, while the build itself (and the test suites) stay on a modern JDK.

## Why

Users on legacy toolchains (Maven 3.9.x on JDK 8/11) currently can't run the plugin at all, even though nothing in DepClean's runtime logic actually needs Java 17. Analysis of modern bytecode is unaffected: ASM 9 parses class files up to the latest Java release regardless of the JVM it runs on.

## How

- **Language downgrades** (main sources only): records → plain classes (accessor names kept, so no call-site churn), pattern-matching `instanceof` → cast-after-check, switch expressions/rules → classic switches, `Set.of`/other Java 9+ APIs → Java 8 equivalents.
- **JGraphT removed entirely**: it was only used in `DefaultCallGraph` as a plain directed graph + DFS reachability. That's now a `Map<String, Set<String>>` adjacency list with an iterative DFS — one less runtime dependency (JGraphT 1.5.x would have required Java 11 anyway).
- **Guardrails**: `enforceBytecodeVersion` (extra-enforcer-rules) fails the build if any runtime dependency ships bytecode newer than Java 8; the compiler emits `--release 8` + `-Xlint:-options` to silence the obsolescence warning.
- **Tests unchanged in spirit**: test sources compile with `testRelease` 17 and run on the build JDK, so JUnit 6 / AssertJ / ITF stay current.
- **Docs**: README (features, usage prerequisites, build-from-source) and CONTRIBUTING updated to state the new runtime floor.

## Verification

- `./mvnw clean install` green (unit + integration tests, checkstyle, enforcer).
- `./gradlew clean publishToMavenLocal build` green for the Gradle plugin against the new core.
- Built jar verified: all classes are `major version: 52` (Java 8), zero JGraphT classes bundled.

## Notes for reviewers

- The Gradle plugin module keeps its own Java 17 toolchain — only the Maven plugin + core target 8.
- `--release 8` is deprecated ("obsolete") on current JDKs; a future JDK will drop it. Until then this is the standard mechanism used by libraries that support Java 8.
- Future dependency bumps (Renovate) must keep Java 8 bytecode for runtime-scoped deps — the new enforcer rule turns violations into hard build failures instead of silent runtime breakage.