### PR TITLE
build: never automerge fixture dependency bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,14 @@
       "enabled": false
     },
     {
+      "description": "IT/FT fixture dependencies have golden output assertions coupled to exact versions and sizes; never automerge, update the goldens in the same PR instead",
+      "matchFileNames": [
+        "depclean-maven-plugin/src/test/resources-its/**",
+        "depclean-gradle-plugin/src/test/resources-fts/**"
+      ],
+      "automerge": false
+    },
+    {
       "description": "Security fix PRs get top priority",
       "matchJsonata": ["isVulnerabilityAlert"],
       "prPriority": 10


### PR DESCRIPTION
Renovate automerged #500/#501, which bump IT/FT fixture dependencies whose golden assertions embed exact versions and jar sizes — master went red (fixed meanwhile by 3266eff/29e1f16). This adds a `packageRule` so fixture dependency bumps are never automerged again; they need the goldens updated in the same PR.

Config validated with `renovate-config-validator`.