### PR TITLE
refactor: resolve SonarCloud issues and eliminate all build warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 target/
 build/
 out/
+bin/
 
 # Gradle
 .gradle/

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,5 @@
+# SonarCloud Automatic Analysis configuration.
+# Test fixture projects consumed by the integration/functional tests are input
+# data with intentionally odd code (default packages, commented-out code, empty
+# tests); exclude them from analysis.
+sonar.exclusions=**/src/test/resources/**,**/src/test/resources-its/**,**/src/test/resources-fts/**

--- a/depclean-core/src/main/java/se/kth/depclean/core/AbstractDebloater.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/AbstractDebloater.java
@@ -15,7 +15,7 @@ public abstract class AbstractDebloater<T> {
 
   protected final ProjectDependencyAnalysis analysis;
 
-  public AbstractDebloater(ProjectDependencyAnalysis analysis) {
+  protected AbstractDebloater(ProjectDependencyAnalysis analysis) {
     this.analysis = analysis;
   }
 

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/ProjectDependencyAnalysisBuilder.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/ProjectDependencyAnalysisBuilder.java
@@ -124,31 +124,30 @@ public class ProjectDependencyAnalysisBuilder {
   }
 
   private Set<Dependency> getUsedInheritedDirectDependencies() {
-    return usedDependencies.stream()
-        .filter(a -> context.getDependencyGraph().inheritedDirectDependencies().contains(a))
-        .peek(dependency -> log.trace("## Used Inherited Direct dependency {}", dependency))
-        .collect(Collectors.toSet());
+    return filterUsedDependencies(
+        context.getDependencyGraph().inheritedDirectDependencies(), "Inherited Direct");
   }
 
   private Set<Dependency> getUsedDirectDependencies() {
-    return usedDependencies.stream()
-        .filter(a -> context.getDependencyGraph().directDependencies().contains(a))
-        .peek(dependency -> log.trace("## Used Direct dependency {}", dependency))
-        .collect(Collectors.toSet());
+    return filterUsedDependencies(context.getDependencyGraph().directDependencies(), "Direct");
   }
 
   private Set<Dependency> getUsedTransitiveDependencies() {
-    return usedDependencies.stream()
-        .filter(a -> context.getDependencyGraph().transitiveDependencies().contains(a))
-        .peek(dependency -> log.trace("## Used Transitive dependency {}", dependency))
-        .collect(Collectors.toSet());
+    return filterUsedDependencies(
+        context.getDependencyGraph().transitiveDependencies(), "Transitive");
   }
 
   private Set<Dependency> getUsedInheritedTransitiveDependencies() {
-    return usedDependencies.stream()
-        .filter(a -> context.getDependencyGraph().inheritedTransitiveDependencies().contains(a))
-        .peek(dependency -> log.trace("## Used Transitive dependency {}", dependency))
-        .collect(Collectors.toSet());
+    return filterUsedDependencies(
+        context.getDependencyGraph().inheritedTransitiveDependencies(), "Inherited Transitive");
+  }
+
+  private Set<Dependency> filterUsedDependencies(
+      Collection<Dependency> candidates, String label) {
+    final Set<Dependency> result =
+        usedDependencies.stream().filter(candidates::contains).collect(Collectors.toSet());
+    result.forEach(dependency -> log.trace("## Used {} dependency {}", label, dependency));
+    return result;
   }
 
   private Set<Dependency> getUnusedDirectDependencies(Set<Dependency> usedDirectDependencies) {

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/ConstantPoolParser.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/ConstantPoolParser.java
@@ -100,12 +100,16 @@ public class ConstantPoolParser {
     buf.getChar(); // minor + ver
     Set<Integer> classes = new HashSet<>();
     Map<Integer, String> stringConstants = new HashMap<>();
-    for (int ix = 1, num = buf.getChar(); ix < num; ix++) {
+    final int num = buf.getChar();
+    int ix = 1;
+    while (ix < num) {
       byte tag = buf.get();
+      // 8-byte constants (long/double) occupy two constant pool slots
+      int slots = 1;
       switch (tag) {
         case CONSTANT_UTF8:
           stringConstants.put(ix, decodeString(buf));
-          continue;
+          break;
         case CONSTANT_CLASS:
         case CONSTANT_STRING:
         case CONSTANT_METHOD_TYPE:
@@ -115,6 +119,7 @@ public class ConstantPoolParser {
         case CONSTANT_METHODREF:
         case CONSTANT_INTERFACEMETHODREF:
         case CONSTANT_NAME_AND_TYPE:
+        case CONSTANT_INVOKE_DYNAMIC:
           buf.getChar();
           buf.getChar();
           break;
@@ -126,18 +131,14 @@ public class ConstantPoolParser {
           break;
         case CONSTANT_DOUBLE:
           buf.getDouble();
-          ix++;
+          slots = 2;
           break;
         case CONSTANT_LONG:
           buf.getLong();
-          ix++;
+          slots = 2;
           break;
         case CONSTANT_METHODHANDLE:
           buf.get();
-          buf.getChar();
-          break;
-        case CONSTANT_INVOKE_DYNAMIC:
-          buf.getChar();
           buf.getChar();
           break;
         case CONSTANT_MODULE:
@@ -145,8 +146,9 @@ public class ConstantPoolParser {
           buf.getChar();
           break;
         default:
-          throw new RuntimeException("Unknown constant pool type '" + tag + "'");
+          throw new IllegalStateException("Unknown constant pool type '" + tag + "'");
       }
+      ix += slots;
     }
     Set<String> result = new HashSet<>();
     for (Integer clazz : classes) {

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
@@ -39,6 +39,8 @@ public class DefaultCallGraph {
   private static final Set<String> projectVertices = new HashSet<>();
   private static final Map<String, Set<String>> usagesPerClass = new HashMap<>();
 
+  private DefaultCallGraph() {}
+
   /**
    * Add an edge to the call graph of classes.
    *

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/DebloatedDependency.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/model/DebloatedDependency.java
@@ -1,6 +1,7 @@
 package se.kth.depclean.core.analysis.model;
 
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 import se.kth.depclean.core.model.Dependency;
 
 /** A debloated dependency. */
@@ -15,5 +16,16 @@ public class DebloatedDependency extends Dependency {
 
   public Set<Dependency> getExclusions() {
     return exclusions;
+  }
+
+  // Exclusions are intentionally not part of the dependency's identity.
+  @Override
+  public boolean equals(@Nullable Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
   }
 }

--- a/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
@@ -130,49 +130,12 @@ public class Dependency {
 
   @NonNull
   private Iterable<ClassName> findRelatedClasses() {
-    final Set<ClassName> relatedClasses = new HashSet<>();
+    final Set<ClassName> classes = new HashSet<>();
     if (file != null && file.getName().endsWith(".jar")) {
       // optimized solution for the jar case
-      try (JarFile jarFile = new JarFile(file)) {
-        Enumeration<JarEntry> jarEntries = jarFile.entries();
-
-        // Protection against ZIP bomb attacks
-        int maxEntries = 100_000; // Maximum number of entries to process
-        int entryCount = 0;
-
-        while (jarEntries.hasMoreElements() && entryCount < maxEntries) {
-          JarEntry jarEntry = jarEntries.nextElement();
-          String entry = jarEntry.getName();
-          entryCount++;
-
-          // Additional protection: skip entries with suspicious characteristics
-          if (entry.length() > 1000) { // Skip entries with very long names
-            continue;
-          }
-
-          if (entry.endsWith(".class")) {
-            relatedClasses.add(new ClassName(entry));
-          }
-        }
-
-        if (entryCount >= maxEntries) {
-          log.warn(
-              "JAR file {} has too many entries ({}), processing truncated",
-              file.getName(),
-              entryCount);
-        }
-      } catch (IOException e) {
-        log.error(e.getMessage(), e);
-      }
+      addClassesFromJar(file, classes);
     } else if (file != null && file.isDirectory()) {
-      try {
-        URL url = file.toURI().toURL();
-        ClassAnalyzer classAnalyzer = new DefaultClassAnalyzer();
-        Set<String> classes = classAnalyzer.analyze(url);
-        classes.forEach(c -> relatedClasses.add(new ClassName(c)));
-      } catch (IOException e) {
-        log.error(e.getMessage(), e);
-      }
+      addClassesFromDirectory(file, classes);
     }
     log.trace(
         "Finding related classes for Dependency: "
@@ -185,8 +148,53 @@ public class Dependency {
             + scope
             + ":"
             + file);
-    log.trace("Related classes: " + relatedClasses);
-    return ImmutableSet.copyOf(relatedClasses);
+    log.trace("Related classes: " + classes);
+    return ImmutableSet.copyOf(classes);
+  }
+
+  private void addClassesFromJar(File jar, Set<ClassName> classes) {
+    try (JarFile jarFile = new JarFile(jar)) {
+      Enumeration<JarEntry> jarEntries = jarFile.entries();
+
+      // Protection against ZIP bomb attacks
+      int maxEntries = 100_000; // Maximum number of entries to process
+      int entryCount = 0;
+
+      while (jarEntries.hasMoreElements() && entryCount < maxEntries) {
+        JarEntry jarEntry = jarEntries.nextElement();
+        String entry = jarEntry.getName();
+        entryCount++;
+
+        // Additional protection: skip entries with suspicious characteristics
+        if (entry.length() > 1000) { // Skip entries with very long names
+          continue;
+        }
+
+        if (entry.endsWith(".class")) {
+          classes.add(new ClassName(entry));
+        }
+      }
+
+      if (entryCount >= maxEntries) {
+        log.warn(
+            "JAR file {} has too many entries ({}), processing truncated",
+            jar.getName(),
+            entryCount);
+      }
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+    }
+  }
+
+  private void addClassesFromDirectory(File directory, Set<ClassName> classes) {
+    try {
+      URL url = directory.toURI().toURL();
+      ClassAnalyzer classAnalyzer = new DefaultClassAnalyzer();
+      Set<String> analyzedClasses = classAnalyzer.analyze(url);
+      analyzedClasses.forEach(c -> classes.add(new ClassName(c)));
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+    }
   }
 
   @NonNull

--- a/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
@@ -78,7 +78,6 @@ public final class JarUtils {
       // Protection against ZIP bomb attacks
       int maxEntries = 10_000; // Maximum number of entries to process
       long maxTotalSize = 1_000_000_000L; // 1 GB maximum total uncompressed size
-      double maxCompressionRatio = 100.0; // Maximum compression ratio
 
       int entryCount = 0;
       long totalSizeUncompressed = 0;
@@ -104,39 +103,8 @@ public final class JarUtils {
         // create the parent directory structure if needed
         destinationParent.mkdirs();
         if (!entry.isDirectory() && !destFile.isDirectory()) {
-          try (BufferedInputStream is = new BufferedInputStream(zip.getInputStream(entry));
-              FileOutputStream fos = new FileOutputStream(destFile);
-              BufferedOutputStream dest = new BufferedOutputStream(fos, BUFFER_SIZE)) {
-
-            int currentByte;
-            // establish buffer for writing file
-            byte[] data = new byte[BUFFER_SIZE];
-            long entrySizeUncompressed = 0;
-
-            // read and write until last byte is encountered
-            while ((currentByte = is.read(data, 0, BUFFER_SIZE)) != -1) {
-              dest.write(data, 0, currentByte);
-              entrySizeUncompressed += currentByte;
-              totalSizeUncompressed += currentByte;
-
-              // Check compression ratio for this entry
-              if (entry.getCompressedSize() > 0) {
-                double compressionRatio =
-                    (double) entrySizeUncompressed / entry.getCompressedSize();
-                if (compressionRatio > maxCompressionRatio) {
-                  throw new IOException(
-                      "ZIP bomb detected: compression ratio too high for entry " + currentEntry);
-                }
-              }
-
-              // Check total uncompressed size
-              if (totalSizeUncompressed > maxTotalSize) {
-                throw new IOException("ZIP bomb detected: total uncompressed size exceeds limit");
-              }
-            }
-            dest.flush();
-            is.close();
-          }
+          totalSizeUncompressed +=
+              extractEntry(zip, entry, destFile, totalSizeUncompressed, maxTotalSize);
         }
         if (currentEntry.endsWith(".jar")
             || currentEntry.endsWith(".war")
@@ -152,6 +120,43 @@ public final class JarUtils {
         throw new IOException(
             "ZIP bomb detected: too many entries in archive (" + entryCount + ")");
       }
+    }
+  }
+
+  /** Extracts a single entry, enforcing ZIP bomb limits; returns its uncompressed size. */
+  private static long extractEntry(
+      ZipFile zip, ZipEntry entry, File destFile, long totalSizeUncompressed, long maxTotalSize)
+      throws IOException {
+    long entrySizeUncompressed = 0;
+    try (BufferedInputStream is = new BufferedInputStream(zip.getInputStream(entry));
+        BufferedOutputStream dest =
+            new BufferedOutputStream(new FileOutputStream(destFile), BUFFER_SIZE)) {
+
+      int currentByte;
+      // establish buffer for writing file
+      byte[] data = new byte[BUFFER_SIZE];
+
+      // read and write until last byte is encountered
+      while ((currentByte = is.read(data, 0, BUFFER_SIZE)) != -1) {
+        dest.write(data, 0, currentByte);
+        entrySizeUncompressed += currentByte;
+        checkCompressionRatio(entry, entrySizeUncompressed);
+        if (totalSizeUncompressed + entrySizeUncompressed > maxTotalSize) {
+          throw new IOException("ZIP bomb detected: total uncompressed size exceeds limit");
+        }
+      }
+      dest.flush();
+    }
+    return entrySizeUncompressed;
+  }
+
+  private static void checkCompressionRatio(ZipEntry entry, long entrySizeUncompressed)
+      throws IOException {
+    double maxCompressionRatio = 100.0; // Maximum compression ratio
+    if (entry.getCompressedSize() > 0
+        && (double) entrySizeUncompressed / entry.getCompressedSize() > maxCompressionRatio) {
+      throw new IOException(
+          "ZIP bomb detected: compression ratio too high for entry " + entry.getName());
     }
   }
 }

--- a/depclean-core/src/test/java/se/kth/depclean/core/DepCleanManagerEnd2EndTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/DepCleanManagerEnd2EndTest.java
@@ -352,7 +352,9 @@ class DepCleanManagerEnd2EndTest {
     }
 
     @Override
-    public void close() {}
+    public void close() {
+      // nothing to release
+    }
 
     public List<LoggingEvent> getLog() {
       return new ArrayList<>(log);

--- a/depclean-core/src/test/java/se/kth/depclean/core/analysis/CollectorClassFileVisitorTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/analysis/CollectorClassFileVisitorTest.java
@@ -14,18 +14,18 @@ class CollectorClassFileVisitorTest {
 
   private static final Logger log = LoggerFactory.getLogger(CollectorClassFileVisitorTest.class);
 
-  private static final File classFile = new File("src/test/resources/analysisResources/test.class");
-  private static final String className = "test";
+  private static final File CLASS_FILE = new File("src/test/resources/analysisResources/test.class");
+  private static final String CLASS_NAME = "test";
   private static final CollectorClassFileVisitor collector = new CollectorClassFileVisitor();
 
   @Test
   @DisplayName("Test that the class is visited and added to the set of visited classes")
   void whenClassIsVisited_thenItIsAddedToTheSetOfVisitedClasses() throws FileNotFoundException {
-    FileInputStream fileInputStream = new FileInputStream(classFile);
+    FileInputStream fileInputStream = new FileInputStream(CLASS_FILE);
     try {
-      collector.visitClass(className, fileInputStream);
+      collector.visitClass(CLASS_NAME, fileInputStream);
     } catch (IllegalArgumentException e) {
-      log.error("Failed to visit the class at: " + classFile.getAbsolutePath());
+      log.error("Failed to visit the class at: " + CLASS_FILE.getAbsolutePath());
     }
     assertThat(collector.getClasses()).isNotEmpty();
   }

--- a/depclean-core/src/test/java/se/kth/depclean/core/analysis/graphTest/DependencyClassFileVisitorTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/analysis/graphTest/DependencyClassFileVisitorTest.java
@@ -13,9 +13,9 @@ import se.kth.depclean.core.analysis.graph.DefaultCallGraph;
 class DependencyClassFileVisitorTest {
 
   // Resource class for testing.
-  private static final File classFile =
+  private static final File CLASS_FILE =
       new File("src/test/resources/asmAndGraphResources/ExampleClass.class");
-  private static final String className = "ExampleClass";
+  private static final String CLASS_NAME = "ExampleClass";
 
   @Test
   @DisplayName(
@@ -24,15 +24,15 @@ class DependencyClassFileVisitorTest {
   void test_that_graph_is_collecting_edges_from_asm_correctly() throws IOException {
 
     ResultCollector resultCollector = new ResultCollector();
-    FileInputStream fileInputStream = new FileInputStream(classFile);
+    FileInputStream fileInputStream = new FileInputStream(CLASS_FILE);
 
     DependencyClassFileVisitor visitor = new DependencyClassFileVisitor();
-    visitor.visitClass(className, fileInputStream);
+    visitor.visitClass(CLASS_NAME, fileInputStream);
 
     // Checking for the expected results.
-    Assertions.assertTrue(DefaultCallGraph.containsVertex(className));
+    Assertions.assertTrue(DefaultCallGraph.containsVertex(CLASS_NAME));
     for (String referencedClassMember : resultCollector.getDependencies()) {
-      Assertions.assertTrue(DefaultCallGraph.containsEdge(className, referencedClassMember));
+      Assertions.assertTrue(DefaultCallGraph.containsEdge(CLASS_NAME, referencedClassMember));
     }
 
     // Confirming the successful termination of DependencyClassFileVisitor object.

--- a/depclean-core/src/test/java/se/kth/depclean/core/fake/FakeDependencyGraph.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/fake/FakeDependencyGraph.java
@@ -8,9 +8,9 @@ import se.kth.depclean.core.model.Dependency;
 
 public class FakeDependencyGraph implements DependencyGraph {
 
-  Dependency COMMONS_IO_DEPENDENCY = createDependency("commons-io");
-  Dependency COMMONS_LANG_DEPENDENCY = createDependency("commons-lang3");
-  Dependency COMMONS_LOGGING_DEPENDENCY = createDependency("commons-logging-api");
+  static final Dependency COMMONS_IO_DEPENDENCY = createDependency("commons-io");
+  static final Dependency COMMONS_LANG_DEPENDENCY = createDependency("commons-lang3");
+  static final Dependency COMMONS_LOGGING_DEPENDENCY = createDependency("commons-logging-api");
 
   @Override
   public Dependency projectCoordinates() {

--- a/depclean-core/src/test/java/se/kth/depclean/core/fake/depmanager/FakeDependencyManager.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/fake/depmanager/FakeDependencyManager.java
@@ -17,8 +17,8 @@ import se.kth.depclean.core.wrapper.LogWrapper;
 
 public class FakeDependencyManager implements DependencyManagerWrapper {
 
-  protected Path RESOURCES_PATH = Paths.get("src/test/resources");
-  protected Path END_2_END_PATH = RESOURCES_PATH.resolve("end2end");
+  protected static final Path RESOURCES_PATH = Paths.get("src/test/resources");
+  protected static final Path END_2_END_PATH = RESOURCES_PATH.resolve("end2end");
 
   private final Logger log;
   private final FakeDependencyGraph dependencyGraph;
@@ -125,7 +125,9 @@ public class FakeDependencyManager implements DependencyManagerWrapper {
   }
 
   @Override
-  public void generateDependencyTree(File treeFile) {}
+  public void generateDependencyTree(File treeFile) {
+    // not needed by the fake
+  }
 
   @Override
   @SuppressWarnings("NullAway")

--- a/depclean-core/src/test/resources/basic_spring_maven_project/pom.xml
+++ b/depclean-core/src/test/resources/basic_spring_maven_project/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.boot</groupId>
@@ -14,7 +16,7 @@
   <name>demo</name>
   <description>Demo project for Spring Boot</description>
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
   </properties>
   <dependencies>
     <dependency>
@@ -23,11 +25,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter-webmvc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
+      <artifactId>spring-boot-starter-webmvc-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -43,7 +45,7 @@
         <!-- see https://github.com/castor-software/depclean -->
         <groupId>se.kth.castor</groupId>
         <artifactId>depclean-maven-plugin</artifactId>
-        <version>2.0.3</version>
+        <version>2.2.0-SNAPSHOT</version>
         <executions>
           <execution>
             <goals>

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/DepCleanGradleAction.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/DepCleanGradleAction.java
@@ -19,7 +19,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
@@ -45,8 +44,14 @@ public class DepCleanGradleAction implements Action<Project> {
   // To get some clear visible results.
   private static final String SEPARATOR = "-------------------------------------------------------";
 
+  private static final String BUILD_DIR = "build";
+
   /** A map [artifact] -> [configuration]. */
   private static Map<ResolvedArtifact, String> ArtifactConfigurationMap = new HashMap<>();
+
+  private static void setArtifactConfigurationMap(Map<ResolvedArtifact, String> map) {
+    ArtifactConfigurationMap = map;
+  }
 
   /** A map [dependencies] -> [size]. */
   private static final Map<String, Long> SizeOfDependencies = new HashMap<>();
@@ -88,10 +93,10 @@ public class DepCleanGradleAction implements Action<Project> {
     final Path projectDirPath = Paths.get(project.getProjectDir().getAbsolutePath());
 
     // Path to the dependency directory.
-    final Path dependencyDirPath = projectDirPath.resolve(Paths.get("build", "Dependency"));
+    final Path dependencyDirPath = projectDirPath.resolve(Paths.get(BUILD_DIR, "Dependency"));
 
     // Path to the libs directory.
-    final Path libsDirPath = projectDirPath.resolve(Paths.get("build", "libs"));
+    final Path libsDirPath = projectDirPath.resolve(Paths.get(BUILD_DIR, "libs"));
 
     DependencyUtils utils = new DependencyUtils();
 
@@ -115,7 +120,7 @@ public class DepCleanGradleAction implements Action<Project> {
     // All declared artifacts of the project.
     Set<ResolvedArtifact> declaredArtifacts = utils.getDeclaredArtifacts(declaredDependencies);
 
-    ArtifactConfigurationMap = utils.getArtifactConfigurationMap();
+    setArtifactConfigurationMap(utils.getArtifactConfigurationMap());
 
     // Adding coordinates of the declared artifacts.
     Set<String> declaredArtifactsGroupArtifactIds = new HashSet<>();
@@ -124,6 +129,74 @@ public class DepCleanGradleAction implements Action<Project> {
       declaredArtifactsGroupArtifactIds.add(name);
     }
 
+    prepareDependencyDirectory(project, dependencyDirPath, libsDirPath, allArtifacts, logger);
+
+    /* Analyze dependencies usage status */
+    DefaultGradleProjectDependencyAnalyzer dependencyAnalyzer =
+        new DefaultGradleProjectDependencyAnalyzer(isIgnoreTest);
+    GradleProjectDependencyAnalysis projectDependencyAnalysis = dependencyAnalyzer.analyze(project);
+
+    /*
+     * Collecting the dependencies in their respective categories after the
+     * dependency analysis has been completed.
+     */
+    assert projectDependencyAnalysis != null;
+    Set<ResolvedArtifact> usedTransitiveArtifacts =
+        projectDependencyAnalysis.getUsedUndeclaredArtifacts();
+    Set<ResolvedArtifact> usedDirectArtifacts =
+        projectDependencyAnalysis.getUsedDeclaredArtifacts();
+    Set<ResolvedArtifact> unusedDirectArtifacts =
+        projectDependencyAnalysis.getUnusedDeclaredArtifacts();
+    Set<ResolvedArtifact> unusedTransitiveArtifacts = new HashSet<>(allArtifacts);
+
+    CoordinateSets coordinates =
+        computeCoordinates(
+            usedDirectArtifacts,
+            usedTransitiveArtifacts,
+            unusedDirectArtifacts,
+            unusedTransitiveArtifacts,
+            declaredArtifactsGroupArtifactIds);
+
+    /* Printing the results to the terminal */
+    printAnalysisResults(coordinates, allUnresolvedDependencies);
+
+    failBuildIfConfigured(coordinates);
+
+    /* Writing the debloated version of the build file */
+    if (createBuildDebloated) {
+      writeDebloatedBuildFile(
+          logger,
+          projectDirPath,
+          usedDirectArtifacts,
+          usedTransitiveArtifacts,
+          unusedTransitiveArtifacts,
+          coordinates.unusedTransitive(),
+          allDependencies);
+    }
+
+    /* Writing the JSON file with the debloat results */
+    if (createResultJson) {
+      writeJsonResult(
+          logger, projectDirPath, project, dependencyAnalyzer, declaredDependencies, coordinates);
+    }
+  }
+
+  /** The six coordinate categories produced by the analysis. */
+  private record CoordinateSets(
+      Set<String> usedDirect,
+      Set<String> usedInherited,
+      Set<String> usedTransitive,
+      Set<String> unusedDirect,
+      Set<String> unusedInherited,
+      Set<String> unusedTransitive) {}
+
+  /** Copies dependencies locally, registers their sizes and decompresses them. */
+  private void prepareDependencyDirectory(
+      Project project,
+      Path dependencyDirPath,
+      Path libsDirPath,
+      Set<ResolvedArtifact> allArtifacts,
+      Logger logger) {
     // Copying dependencies locally to get their size.
     File dependencyDirectory = copyDependenciesLocally(dependencyDirPath, allArtifacts, logger);
 
@@ -153,47 +226,30 @@ public class DepCleanGradleAction implements Action<Project> {
 
     /* Decompress dependencies */
     decompressDependencies(dependencyDirectory, dependencyDirPath.toString());
+  }
 
-    /* Analyze dependencies usage status */
-    GradleProjectDependencyAnalysis projectDependencyAnalysis;
-    DefaultGradleProjectDependencyAnalyzer dependencyAnalyzer =
-        new DefaultGradleProjectDependencyAnalyzer(isIgnoreTest);
-    projectDependencyAnalysis = dependencyAnalyzer.analyze(project);
-
-    /*
-     * Collecting the dependencies in their respective categories after the
-     * dependency analysis has been completed.
-     */
-    assert projectDependencyAnalysis != null;
-    Set<ResolvedArtifact> usedTransitiveArtifacts =
-        projectDependencyAnalysis.getUsedUndeclaredArtifacts();
-    Set<ResolvedArtifact> usedDirectArtifacts =
-        projectDependencyAnalysis.getUsedDeclaredArtifacts();
-    Set<ResolvedArtifact> unusedDirectArtifacts =
-        projectDependencyAnalysis.getUnusedDeclaredArtifacts();
-    Set<ResolvedArtifact> unusedTransitiveArtifacts = new HashSet<>(allArtifacts);
-
+  /** Splits the analysed artifacts into the six coordinate categories. */
+  private CoordinateSets computeCoordinates(
+      Set<ResolvedArtifact> usedDirectArtifacts,
+      Set<ResolvedArtifact> usedTransitiveArtifacts,
+      Set<ResolvedArtifact> unusedDirectArtifacts,
+      Set<ResolvedArtifact> unusedTransitiveArtifacts,
+      Set<String> declaredArtifactsGroupArtifactIds) {
     // --- used dependencies
     Set<String> usedDirectArtifactsCoordinates = new HashSet<>();
     Set<String> usedInheritedArtifactsCoordinates = new HashSet<>();
     Set<String> usedTransitiveArtifactsCoordinates = new HashSet<>();
 
-    for (ResolvedArtifact artifact : usedDirectArtifacts) {
-      String artifactGroupArtifactIds = getName(artifact);
-      if (declaredArtifactsGroupArtifactIds.contains(artifactGroupArtifactIds)) {
-        // the artifact is declared in the build file
-        usedDirectArtifactsCoordinates.add(artifactGroupArtifactIds);
-      } else {
-        // the artifact is inherited
-        usedInheritedArtifactsCoordinates.add(artifactGroupArtifactIds);
-      }
-    }
+    partitionByDeclared(
+        usedDirectArtifacts,
+        declaredArtifactsGroupArtifactIds,
+        usedDirectArtifactsCoordinates,
+        usedInheritedArtifactsCoordinates);
 
     // TODO Fix: The used transitive dependencies induced by inherited
     // dependencies should be considered as used inherited.
     for (ResolvedArtifact artifact : usedTransitiveArtifacts) {
-      String artifactGroupArtifactIds = getName(artifact);
-      usedTransitiveArtifactsCoordinates.add(artifactGroupArtifactIds);
+      usedTransitiveArtifactsCoordinates.add(getName(artifact));
     }
 
     // --- unused dependencies
@@ -201,20 +257,14 @@ public class DepCleanGradleAction implements Action<Project> {
     Set<String> unusedInheritedArtifactsCoordinates = new HashSet<>();
     Set<String> unusedTransitiveArtifactsCoordinates = new HashSet<>();
 
-    for (ResolvedArtifact artifact : unusedDirectArtifacts) {
-      String artifactGroupArtifactIds = getName(artifact);
-      if (declaredArtifactsGroupArtifactIds.contains(artifactGroupArtifactIds)) {
-        // artifact is declared in build file
-        unusedDirectArtifactsCoordinates.add(artifactGroupArtifactIds);
-      } else {
-        // the artifact is inherited
-        unusedInheritedArtifactsCoordinates.add(artifactGroupArtifactIds);
-      }
-    }
+    partitionByDeclared(
+        unusedDirectArtifacts,
+        declaredArtifactsGroupArtifactIds,
+        unusedDirectArtifactsCoordinates,
+        unusedInheritedArtifactsCoordinates);
 
     for (ResolvedArtifact artifact : unusedTransitiveArtifacts) {
-      String artifactGroupArtifactIds = getName(artifact);
-      unusedTransitiveArtifactsCoordinates.add(artifactGroupArtifactIds);
+      unusedTransitiveArtifactsCoordinates.add(getName(artifact));
     }
 
     // Filtering with name(String) because removeAll function didn't work on
@@ -251,20 +301,48 @@ public class DepCleanGradleAction implements Action<Project> {
           excludeDependencies(unusedInheritedArtifactsCoordinates);
     }
 
-    /* Printing the results to the terminal */
+    return new CoordinateSets(
+        usedDirectArtifactsCoordinates,
+        usedInheritedArtifactsCoordinates,
+        usedTransitiveArtifactsCoordinates,
+        unusedDirectArtifactsCoordinates,
+        unusedInheritedArtifactsCoordinates,
+        unusedTransitiveArtifactsCoordinates);
+  }
+
+  /** Adds each artifact's coordinates to the declared or inherited output set. */
+  private static void partitionByDeclared(
+      Set<ResolvedArtifact> artifacts,
+      Set<String> declaredArtifactsGroupArtifactIds,
+      Set<String> declaredOut,
+      Set<String> inheritedOut) {
+    for (ResolvedArtifact artifact : artifacts) {
+      String artifactGroupArtifactIds = getName(artifact);
+      if (declaredArtifactsGroupArtifactIds.contains(artifactGroupArtifactIds)) {
+        // the artifact is declared in the build file
+        declaredOut.add(artifactGroupArtifactIds);
+      } else {
+        // the artifact is inherited
+        inheritedOut.add(artifactGroupArtifactIds);
+      }
+    }
+  }
+
+  /** Prints the analysis results to the terminal. */
+  private void printAnalysisResults(
+      CoordinateSets coordinates, Set<UnresolvedDependency> allUnresolvedDependencies) {
     printString(SEPARATOR);
     printString(" D E P C L E A N   A N A L Y S I S   R E S U L T S");
     printString(SEPARATOR);
     printString(SEPARATOR);
-    printInfoOfDependencies("Used direct dependencies", usedDirectArtifactsCoordinates);
-    printInfoOfDependencies("Used inherited dependencies", usedInheritedArtifactsCoordinates);
-    printInfoOfDependencies("Used transitive dependencies", usedTransitiveArtifactsCoordinates);
+    printInfoOfDependencies("Used direct dependencies", coordinates.usedDirect());
+    printInfoOfDependencies("Used inherited dependencies", coordinates.usedInherited());
+    printInfoOfDependencies("Used transitive dependencies", coordinates.usedTransitive());
+    printInfoOfDependencies("Potentially unused direct dependencies", coordinates.unusedDirect());
     printInfoOfDependencies(
-        "Potentially unused direct dependencies", unusedDirectArtifactsCoordinates);
+        "Potentially unused inherited dependencies", coordinates.unusedInherited());
     printInfoOfDependencies(
-        "Potentially unused inherited dependencies", unusedInheritedArtifactsCoordinates);
-    printInfoOfDependencies(
-        "Potentially unused transitive dependencies", unusedTransitiveArtifactsCoordinates);
+        "Potentially unused transitive dependencies", coordinates.unusedTransitive());
 
     printString(SEPARATOR);
 
@@ -301,163 +379,182 @@ public class DepCleanGradleAction implements Action<Project> {
               + ": ");
       ignoreDependencies.forEach(s -> printString("\t" + s));
     }
+  }
 
+  /** Fails the build if configured to do so and unused dependencies were found. */
+  private void failBuildIfConfigured(CoordinateSets coordinates) {
     /* Fail the build if there are unused direct dependencies */
-    if (failIfUnusedDirect && !unusedDirectArtifactsCoordinates.isEmpty()) {
+    if (failIfUnusedDirect && !coordinates.unusedDirect().isEmpty()) {
       throw new GradleException(
           "Build failed due to unused direct dependencies"
               + " in the dependency tree of the project.");
     }
 
-    /* Fail the build if there are unused direct dependencies */
-    if (failIfUnusedTransitive && !unusedTransitiveArtifactsCoordinates.isEmpty()) {
+    /* Fail the build if there are unused transitive dependencies */
+    if (failIfUnusedTransitive && !coordinates.unusedTransitive().isEmpty()) {
       throw new GradleException(
           "Build failed due to unused transitive dependencies"
               + " in the dependency tree of the project.");
     }
 
-    /* Fail the build if there are unused direct dependencies */
-    if (failIfUnusedInherited && !unusedInheritedArtifactsCoordinates.isEmpty()) {
+    /* Fail the build if there are unused inherited dependencies */
+    if (failIfUnusedInherited && !coordinates.unusedInherited().isEmpty()) {
       throw new GradleException(
           "Build failed due to unused inherited dependencies"
               + " in the dependency tree of the project.");
     }
+  }
 
-    /* Writing the debloated version of the pom */
-    if (createBuildDebloated) {
-      logger.lifecycle("Starting debloating dependencies");
-
-      // All dependencies which will be added directly to the desired file.
-      Set<ResolvedArtifact> dependenciesToAdd = new HashSet<>();
-
-      /* Adding used direct dependencies */
-      try {
-        logger.lifecycle("Adding " + usedDirectArtifacts.size() + " used direct dependencies");
-        dependenciesToAdd.addAll(usedDirectArtifacts);
-      } catch (Exception e) {
-        throw new GradleException("Failed to add used direct dependencies", e);
-      }
-
-      /* Add used transitive as direct dependencies */
-      try {
-        if (!usedTransitiveArtifacts.isEmpty()) {
-          logger.lifecycle(
-              "Adding "
-                  + usedTransitiveArtifacts.size()
-                  + " used transitive dependencies as direct dependencies.");
-          dependenciesToAdd.addAll(usedTransitiveArtifacts);
+  /**
+   * A multi-map [parent] -> [child] i.e. this will keep a track of from which dependency the unused
+   * transitive dependencies should be excluded. Also, here multi-map is preferred as one transitive
+   * dependency can have more than one parent.
+   */
+  private Multimap<String, String> computeExcludedTransitiveArtifactsMap(
+      Set<ResolvedDependency> allDependencies, Set<String> unusedTransitiveArtifactsCoordinates) {
+    Multimap<String, String> excludedTransitiveArtifactsMap = ArrayListMultimap.create();
+    // A set that contains all the transitive children of project's dependencies.
+    Set<ResolvedDependency> allChildren = getAllChildren(allDependencies);
+    for (String artifact : unusedTransitiveArtifactsCoordinates) {
+      String unusedTransitiveDependencyId = getArtifactGroupArtifactId(artifact);
+      for (ResolvedDependency dependency : allChildren) {
+        if (dependency.getName().equals(unusedTransitiveDependencyId)) {
+          // i.e. this dependency should be excluded from all it's parents.
+          Set<ResolvedDependency> parents = dependency.getParents();
+          parents.forEach(
+              s -> excludedTransitiveArtifactsMap.put(s.getName(), unusedTransitiveDependencyId));
+          break; // Not need to check further.
         }
-      } catch (Exception e) {
-        throw new GradleException("Failed to add used transitive dependencies", e);
       }
+    }
+    return excludedTransitiveArtifactsMap;
+  }
 
-      /* Exclude unused transitive dependencies */
+  /** Writes the debloated-dependencies.gradle file. */
+  private void writeDebloatedBuildFile(
+      Logger logger,
+      Path projectDirPath,
+      Set<ResolvedArtifact> usedDirectArtifacts,
+      Set<ResolvedArtifact> usedTransitiveArtifacts,
+      Set<ResolvedArtifact> unusedTransitiveArtifacts,
+      Set<String> unusedTransitiveArtifactsCoordinates,
+      Set<ResolvedDependency> allDependencies) {
+    logger.lifecycle("Starting debloating dependencies");
 
-      /*
-       * A multi-map [parent] -> [child] i.e. this will keep a track of from which
-       * dependency
-       * the unused transitive dependencies should be excluded. Also, here multi-map
-       * is preferred
-       * as one transitive dependency can have more than one parent.
-       */
-      Multimap<String, String> excludedTransitiveArtifactsMap = ArrayListMultimap.create();
+    // All dependencies which will be added directly to the desired file.
+    Set<ResolvedArtifact> dependenciesToAdd = new HashSet<>();
 
-      // A set that contains all the transitive children of project's dependencies.
-      Set<ResolvedDependency> allChildren = getAllChildren(allDependencies);
-      try {
-        if (!unusedTransitiveArtifacts.isEmpty()) {
-          logger.lifecycle(
-              "Excluding "
-                  + unusedTransitiveArtifactsCoordinates.size()
-                  + " unused transitive dependencies one-by-one.");
-          for (String artifact : unusedTransitiveArtifactsCoordinates) {
-            String unusedTransitiveDependencyId = getArtifactGroupArtifactId(artifact);
-            for (ResolvedDependency dependency : allChildren) {
-              if (dependency.getName().equals(unusedTransitiveDependencyId)) {
-                // i.e. this dependency should be excluded from all it's parents.
-                Set<ResolvedDependency> parents = dependency.getParents();
-                parents.forEach(
-                    s ->
-                        excludedTransitiveArtifactsMap.put(
-                            s.getName(), unusedTransitiveDependencyId));
-                break; // Not need to check further.
-              }
-            }
-          }
-        }
-      } catch (Exception e) {
-        throw new GradleException("Failed to exclude unused transitive dependencies", e);
-      }
-
-      /* Write the debloated-dependencies.gradle file */
-      final Path pathToDebloatedDependencies =
-          projectDirPath.resolve("debloated-dependencies.gradle");
-      File debloatedDependencies = pathToDebloatedDependencies.toFile();
-      try {
-        // Delete the previous existence (if exist).
-        if (debloatedDependencies.exists()) {
-          se.kth.depclean.util.FileUtils.forceDelete(debloatedDependencies);
-          debloatedDependencies.createNewFile();
-        }
-      } catch (IOException e) {
-        logger.error("Error managing debloated dependencies file", e);
-      }
-
-      try {
-        GradleWritingUtils.writeGradle(
-            debloatedDependencies, dependenciesToAdd, excludedTransitiveArtifactsMap);
-      } catch (IOException e) {
-        throw new GradleException("Failed to write debloated-dependencies.gradle", e);
-      }
-      logger.lifecycle("Dependencies debloated successfully");
-      logger.lifecycle(
-          "debloated-dependencies.gradle file created in: " + pathToDebloatedDependencies);
+    /* Adding used direct dependencies */
+    try {
+      logger.lifecycle("Adding " + usedDirectArtifacts.size() + " used direct dependencies");
+      dependenciesToAdd.addAll(usedDirectArtifacts);
+    } catch (Exception e) {
+      throw new GradleException("Failed to add used direct dependencies", e);
     }
 
-    /* Writing the JSON file with the debloat results */
-    if (createResultJson) {
-      printString("Creating depclean-results.json, please wait...");
-      final File jsonFile =
-          projectDirPath.resolve("build" + File.separator + "depclean-results.json").toFile();
-      final File classUsageFile =
-          projectDirPath.resolve("build" + File.separator + "class-usage.csv").toFile();
-      if (createClassUsageCsv) {
-        printString("Creating class-usage.csv, please wait...");
-        try {
-          FileUtils.write(
-              classUsageFile, "OriginClass,TargetClass,Dependency\n", StandardCharsets.UTF_8);
-        } catch (IOException e) {
-          logger.error("Error writing the CSV header.");
+    /* Add used transitive as direct dependencies */
+    try {
+      if (!usedTransitiveArtifacts.isEmpty()) {
+        logger.lifecycle(
+            "Adding "
+                + usedTransitiveArtifacts.size()
+                + " used transitive dependencies as direct dependencies.");
+        dependenciesToAdd.addAll(usedTransitiveArtifacts);
+      }
+    } catch (Exception e) {
+      throw new GradleException("Failed to add used transitive dependencies", e);
+    }
+
+    /* Exclude unused transitive dependencies */
+    Multimap<String, String> excludedTransitiveArtifactsMap;
+    try {
+      if (!unusedTransitiveArtifacts.isEmpty()) {
+        logger.lifecycle(
+            "Excluding "
+                + unusedTransitiveArtifactsCoordinates.size()
+                + " unused transitive dependencies one-by-one.");
+      }
+      excludedTransitiveArtifactsMap =
+          computeExcludedTransitiveArtifactsMap(
+              allDependencies, unusedTransitiveArtifactsCoordinates);
+    } catch (Exception e) {
+      throw new GradleException("Failed to exclude unused transitive dependencies", e);
+    }
+
+    /* Write the debloated-dependencies.gradle file */
+    final Path pathToDebloatedDependencies =
+        projectDirPath.resolve("debloated-dependencies.gradle");
+    File debloatedDependencies = pathToDebloatedDependencies.toFile();
+    try {
+      // Delete the previous existence (if exist).
+      if (debloatedDependencies.exists()) {
+        se.kth.depclean.util.FileUtils.forceDelete(debloatedDependencies);
+        if (!debloatedDependencies.createNewFile()) {
+          logger.warn("Could not recreate file " + debloatedDependencies.getAbsolutePath());
         }
       }
-      JsonResultWriter jsonResultWriter =
-          new JsonResultWriter(
-              project,
-              classUsageFile,
-              dependencyAnalyzer,
-              SizeOfDependencies,
-              createClassUsageCsv,
-              declaredDependencies,
-              usedDirectArtifactsCoordinates,
-              usedInheritedArtifactsCoordinates,
-              usedTransitiveArtifactsCoordinates,
-              unusedDirectArtifactsCoordinates,
-              unusedInheritedArtifactsCoordinates,
-              unusedTransitiveArtifactsCoordinates);
+    } catch (IOException e) {
+      logger.error("Error managing debloated dependencies file", e);
+    }
+
+    try {
+      GradleWritingUtils.writeGradle(
+          debloatedDependencies, dependenciesToAdd, excludedTransitiveArtifactsMap);
+    } catch (IOException e) {
+      throw new GradleException("Failed to write debloated-dependencies.gradle", e);
+    }
+    logger.lifecycle("Dependencies debloated successfully");
+    logger.lifecycle(
+        "debloated-dependencies.gradle file created in: " + pathToDebloatedDependencies);
+  }
+
+  /** Writes the depclean-results.json file (and optionally the class-usage.csv file). */
+  private void writeJsonResult(
+      Logger logger,
+      Path projectDirPath,
+      Project project,
+      DefaultGradleProjectDependencyAnalyzer dependencyAnalyzer,
+      Set<ResolvedDependency> declaredDependencies,
+      CoordinateSets coordinates) {
+    printString("Creating depclean-results.json, please wait...");
+    final File jsonFile =
+        projectDirPath.resolve(BUILD_DIR + File.separator + "depclean-results.json").toFile();
+    final File classUsageFile =
+        projectDirPath.resolve(BUILD_DIR + File.separator + "class-usage.csv").toFile();
+    if (createClassUsageCsv) {
+      printString("Creating class-usage.csv, please wait...");
       try {
-        FileWriter fw = new FileWriter(jsonFile, StandardCharsets.UTF_8);
-        jsonResultWriter.write(fw);
-        fw.flush();
-        fw.close();
+        FileUtils.write(
+            classUsageFile, "OriginClass,TargetClass,Dependency\n", StandardCharsets.UTF_8);
       } catch (IOException e) {
-        logger.error("Unable to generate JSON file.");
+        logger.error("Error writing the CSV header.");
       }
-      if (jsonFile.exists()) {
-        logger.lifecycle("depclean-results.json file created in: " + jsonFile.getAbsolutePath());
-      }
-      if (classUsageFile.exists()) {
-        logger.lifecycle("class-usage.csv file created in: " + classUsageFile.getAbsolutePath());
-      }
+    }
+    JsonResultWriter jsonResultWriter =
+        new JsonResultWriter(
+            project,
+            classUsageFile,
+            dependencyAnalyzer,
+            SizeOfDependencies,
+            createClassUsageCsv,
+            declaredDependencies,
+            coordinates.usedDirect(),
+            coordinates.usedInherited(),
+            coordinates.usedTransitive(),
+            coordinates.unusedDirect(),
+            coordinates.unusedInherited(),
+            coordinates.unusedTransitive());
+    try (FileWriter fw = new FileWriter(jsonFile, StandardCharsets.UTF_8)) {
+      jsonResultWriter.write(fw);
+      fw.flush();
+    } catch (IOException e) {
+      logger.error("Unable to generate JSON file.");
+    }
+    if (jsonFile.exists()) {
+      logger.lifecycle("depclean-results.json file created in: " + jsonFile.getAbsolutePath());
+    }
+    if (classUsageFile.exists()) {
+      logger.lifecycle("class-usage.csv file created in: " + classUsageFile.getAbsolutePath());
     }
   }
 
@@ -584,7 +681,7 @@ public class DepCleanGradleAction implements Action<Project> {
     List<String> sortedDependencies =
         dependencies.stream()
             .sorted(Comparator.comparing(this::getSizeOfDependency).reversed())
-            .collect(Collectors.toList());
+            .toList();
     sortedDependencies.forEach(s -> printString("\t" + s + " (" + getSize(s) + ")"));
   }
 

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/analysis/DefaultGradleProjectDependencyAnalyzer.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/analysis/DefaultGradleProjectDependencyAnalyzer.java
@@ -155,40 +155,7 @@ public class DefaultGradleProjectDependencyAnalyzer implements GradleProjectDepe
       File file = artifact.getFile();
       if (file.getName().endsWith(".jar")) {
         // optimized solution for the jar case
-        try (JarFile jarFile = new JarFile(file)) {
-          Enumeration<JarEntry> jarEntries = jarFile.entries();
-          Set<String> classes = new HashSet<>();
-
-          // Protection against ZIP bomb attacks
-          int maxEntries = 100_000; // Maximum number of entries to process
-          int entryCount = 0;
-
-          while (jarEntries.hasMoreElements() && entryCount < maxEntries) {
-            JarEntry jarEntry = jarEntries.nextElement();
-            String entry = jarEntry.getName();
-            entryCount++;
-
-            // Additional protection: skip entries with suspicious characteristics
-            if (entry.length() > 1000) { // Skip entries with very long names
-              continue;
-            }
-
-            if (entry.endsWith(".class")) {
-              String className = entry.replace('/', '.');
-              className = className.substring(0, className.length() - ".class".length());
-              classes.add(className);
-            }
-          }
-
-          if (entryCount >= maxEntries) {
-            log.warn(
-                "JAR file {} has too many entries ({}), processing truncated",
-                file.getName(),
-                entryCount);
-          }
-
-          artifactClassMap.put(artifact, classes);
-        }
+        artifactClassMap.put(artifact, classesFromJar(file));
       } else if (file.isDirectory()) {
         URL url = file.toURI().toURL();
         Set<String> classes = classAnalyzer.analyze(url);
@@ -196,6 +163,44 @@ public class DefaultGradleProjectDependencyAnalyzer implements GradleProjectDepe
       }
     }
     return artifactClassMap;
+  }
+
+  /** Collects the class names contained in a jar file, enforcing ZIP bomb limits. */
+  private Set<String> classesFromJar(File file) throws IOException {
+    try (JarFile jarFile = new JarFile(file)) {
+      Enumeration<JarEntry> jarEntries = jarFile.entries();
+      Set<String> classes = new HashSet<>();
+
+      // Protection against ZIP bomb attacks
+      int maxEntries = 100_000; // Maximum number of entries to process
+      int entryCount = 0;
+
+      while (jarEntries.hasMoreElements() && entryCount < maxEntries) {
+        JarEntry jarEntry = jarEntries.nextElement();
+        String entry = jarEntry.getName();
+        entryCount++;
+
+        // Additional protection: skip entries with suspicious characteristics
+        if (entry.length() > 1000) { // Skip entries with very long names
+          continue;
+        }
+
+        if (entry.endsWith(".class")) {
+          String className = entry.replace('/', '.');
+          className = className.substring(0, className.length() - ".class".length());
+          classes.add(className);
+        }
+      }
+
+      if (entryCount >= maxEntries) {
+        log.warn(
+            "JAR file {} has too many entries ({}), processing truncated",
+            file.getName(),
+            entryCount);
+      }
+
+      return classes;
+    }
   }
 
   /**

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/analysis/GradleProjectDependencyAnalysis.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/analysis/GradleProjectDependencyAnalysis.java
@@ -103,14 +103,14 @@ public class GradleProjectDependencyAnalysis {
     }
 
     if (!getUsedUndeclaredArtifacts().isEmpty()) {
-      if (buffer.length() > 0) {
+      if (!buffer.isEmpty()) {
         buffer.append(",");
       }
       buffer.append("usedUndeclaredArtifacts=").append(getUsedUndeclaredArtifacts());
     }
 
     if (!getUnusedDeclaredArtifacts().isEmpty()) {
-      if (buffer.length() > 0) {
+      if (!buffer.isEmpty()) {
         buffer.append(",");
       }
       buffer.append("unusedDeclaredArtifacts=").append(getUnusedDeclaredArtifacts());

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/DependencyUtils.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/DependencyUtils.java
@@ -11,11 +11,12 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DependencyUtils {
 
-  /** Ctor. */
-  public DependencyUtils() {}
+  private static final Logger log = LoggerFactory.getLogger(DependencyUtils.class);
 
   /** A map [artifact] -> [configuration]. */
   private static final Map<ResolvedArtifact, String> ArtifactConfigurationMap = new HashMap<>();
@@ -51,51 +52,54 @@ public class DependencyUtils {
    */
   public Set<Configuration> getResolvableConfigurations(Project project) {
     ConfigurationContainer configurationContainer = project.getConfigurations();
-    Set<Configuration> resolvableConfigurations = new HashSet<>();
 
     // Use a very conservative approach - only include configurations we know work
-    String[] safeConfigurationNames = {
-      "compileClasspath", "runtimeClasspath", "testCompileClasspath", "testRuntimeClasspath"
-    };
-
-    for (String configName : safeConfigurationNames) {
-      Configuration config = configurationContainer.findByName(configName);
-      if (config != null && config.isCanBeResolved()) {
-        try {
-          // Double-check by trying to access basic metadata
-          config.getState();
-          resolvableConfigurations.add(config);
-          project.getLogger().debug("Including safe configuration: {}", configName);
-        } catch (Exception e) {
-          project
-              .getLogger()
-              .debug("Skipping problematic safe configuration {}: {}", configName, e.getMessage());
-        }
-      }
-    }
+    Set<Configuration> resolvableConfigurations =
+        collectResolvableConfigurations(
+            project,
+            configurationContainer,
+            new String[] {
+              "compileClasspath", "runtimeClasspath", "testCompileClasspath", "testRuntimeClasspath"
+            },
+            "safe");
 
     // If no safe configurations found, try legacy configurations
     if (resolvableConfigurations.isEmpty()) {
-      String[] legacyConfigurationNames = {"compile", "runtime", "testCompile", "testRuntime"};
-      for (String configName : legacyConfigurationNames) {
-        Configuration config = configurationContainer.findByName(configName);
-        if (config != null && config.isCanBeResolved()) {
-          try {
-            config.getState();
-            resolvableConfigurations.add(config);
-            project.getLogger().debug("Including legacy configuration: {}", configName);
-          } catch (Exception e) {
-            project
-                .getLogger()
-                .debug(
-                    "Skipping problematic legacy configuration {}: {}", configName, e.getMessage());
-          }
-        }
-      }
+      resolvableConfigurations =
+          collectResolvableConfigurations(
+              project,
+              configurationContainer,
+              new String[] {"compile", "runtime", "testCompile", "testRuntime"},
+              "legacy");
     }
 
     project.getLogger().info("Found {} resolvable configurations", resolvableConfigurations.size());
     return resolvableConfigurations;
+  }
+
+  private Set<Configuration> collectResolvableConfigurations(
+      Project project, ConfigurationContainer container, String[] configNames, String label) {
+    Set<Configuration> result = new HashSet<>();
+    for (String configName : configNames) {
+      Configuration config = container.findByName(configName);
+      if (config != null && config.isCanBeResolved()) {
+        try {
+          // Double-check by trying to access basic metadata
+          config.getState();
+          result.add(config);
+          project.getLogger().debug("Including {} configuration: {}", label, configName);
+        } catch (Exception e) {
+          project
+              .getLogger()
+              .debug(
+                  "Skipping problematic {} configuration {}: {}",
+                  label,
+                  configName,
+                  e.getMessage());
+        }
+      }
+    }
+    return result;
   }
 
   /**
@@ -142,17 +146,8 @@ public class DependencyUtils {
   public Set<ResolvedDependency> getAllDependencies(final Set<Configuration> configurations) {
     Set<ResolvedDependency> allDependencies = new HashSet<>();
     for (Configuration configuration : configurations) {
-      String configName = configuration.getName();
-
-      // Skip configurations that are not resolvable
-      if (!configuration.isCanBeResolved()) {
-        System.out.println("Skipping non-resolvable configuration: " + configName);
-        continue;
-      }
-
-      // Skip configurations that are known to be problematic
-      if (isExcludedConfiguration(configName)) {
-        System.out.println("Skipping excluded configuration: " + configName);
+      // Skip configurations that are not resolvable or known to be problematic
+      if (shouldSkipConfiguration(configuration, "")) {
         continue;
       }
 
@@ -164,14 +159,27 @@ public class DependencyUtils {
                 .getAllModuleDependencies());
       } catch (Exception e) {
         // Log the error but continue with other configurations
-        System.out.println(
-            "Warning: Could not resolve dependencies for configuration '"
-                + configName
-                + "': "
-                + e.getMessage());
+        log.warn(
+            "Warning: Could not resolve dependencies for configuration '{}': {}",
+            configuration.getName(),
+            e.getMessage());
       }
     }
     return allDependencies;
+  }
+
+  /** Logs and returns true when a configuration must be skipped during analysis. */
+  private boolean shouldSkipConfiguration(Configuration configuration, String context) {
+    String configName = configuration.getName();
+    if (!configuration.isCanBeResolved()) {
+      log.info("Skipping non-resolvable configuration{}: {}", context, configName);
+      return true;
+    }
+    if (isExcludedConfiguration(configName)) {
+      log.info("Skipping excluded configuration{}: {}", context, configName);
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -211,11 +219,10 @@ public class DependencyUtils {
                 .getUnresolvedModuleDependencies());
       } catch (Exception e) {
         // Log the error but continue with other configurations
-        System.out.println(
-            "Warning: Could not get unresolved dependencies for configuration '"
-                + configuration.getName()
-                + "': "
-                + e.getMessage());
+        log.warn(
+            "Warning: Could not get unresolved dependencies for configuration '{}': {}",
+            configuration.getName(),
+            e.getMessage());
       }
     }
     return allUnresolvedDependencies;
@@ -231,19 +238,8 @@ public class DependencyUtils {
   public Set<ResolvedDependency> getDeclaredDependencies(final Set<Configuration> configurations) {
     Set<ResolvedDependency> declaredDependency = new HashSet<>();
     for (Configuration configuration : configurations) {
-      String configName = configuration.getName();
-
-      // Skip configurations that are not resolvable
-      if (!configuration.isCanBeResolved()) {
-        System.out.println(
-            "Skipping non-resolvable configuration in getDeclaredDependencies: " + configName);
-        continue;
-      }
-
-      // Skip configurations that are known to be problematic
-      if (isExcludedConfiguration(configName)) {
-        System.out.println(
-            "Skipping excluded configuration in getDeclaredDependencies: " + configName);
+      // Skip configurations that are not resolvable or known to be problematic
+      if (shouldSkipConfiguration(configuration, " in getDeclaredDependencies")) {
         continue;
       }
 
@@ -255,11 +251,10 @@ public class DependencyUtils {
                 .getFirstLevelModuleDependencies());
       } catch (Exception e) {
         // Log the error but continue with other configurations
-        System.out.println(
-            "Warning: Could not get declared dependencies for configuration '"
-                + configName
-                + "': "
-                + e.getMessage());
+        log.warn(
+            "Warning: Could not get declared dependencies for configuration '{}': {}",
+            configuration.getName(),
+            e.getMessage());
       }
     }
     return declaredDependency;

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/GradleWritingUtils.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/GradleWritingUtils.java
@@ -19,6 +19,8 @@ import se.kth.depclean.DepCleanGradleAction;
 
 public class GradleWritingUtils {
 
+  private GradleWritingUtils() {}
+
   /**
    * Writes the debloated-dependencies.gradle.
    *

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/json/JsonResultWriter.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/json/JsonResultWriter.java
@@ -241,7 +241,6 @@ public class JsonResultWriter {
     if (dependencyAnalyzer.getDependenciesClassesMap().containsKey(dependencyId)) {
       for (ClassName usedType :
           dependencyAnalyzer.getDependenciesClassesMap().get(dependencyId).getUsedTypes()) {
-        System.out.println("Used type: " + usedType.toString());
         usedTypes.value(usedType.getValue());
       }
     }
@@ -260,9 +259,8 @@ public class JsonResultWriter {
   }
 
   private void writeClassUsageCsv(String dependencyId) throws IOException {
-    DefaultCallGraph defaultCallGraph = new DefaultCallGraph();
     for (Map.Entry<String, Set<String>> usagePerClassMap :
-        defaultCallGraph.getUsagesPerClass().entrySet()) {
+        DefaultCallGraph.getUsagesPerClass().entrySet()) {
       String key = usagePerClassMap.getKey();
       Set<String> value = usagePerClassMap.getValue();
       for (String s : value) {

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenInvoker.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenInvoker.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -398,7 +397,7 @@ public final class MavenInvoker {
     /** The handles of the descendants of the process and of the process itself. */
     private static List<Object> treeOf(Process process) {
       if (TO_HANDLE == null || DESCENDANTS == null) {
-        return Collections.emptyList();
+        return new ArrayList<>();
       }
       try {
         Object handle = TO_HANDLE.invoke(process);
@@ -408,7 +407,7 @@ public final class MavenInvoker {
         return tree;
       } catch (ReflectiveOperationException | RuntimeException e) {
         log.debug("Unable to list the process tree: {}", e.getMessage());
-        return Collections.emptyList();
+        return new ArrayList<>();
       }
     }
 

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/util/json/NodeAdapter.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/util/json/NodeAdapter.java
@@ -120,9 +120,8 @@ public class NodeAdapter extends TypeAdapter<Node> {
   }
 
   private void writeCallGraphCsv(String canonical) throws IOException {
-    DefaultCallGraph defaultCallGraph = new DefaultCallGraph();
     for (Map.Entry<String, Set<String>> usagePerClassMap :
-        defaultCallGraph.getUsagesPerClass().entrySet()) {
+        DefaultCallGraph.getUsagesPerClass().entrySet()) {
       String key = usagePerClassMap.getKey();
       Set<String> value = usagePerClassMap.getValue();
       for (String s : value) {

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
@@ -123,7 +123,7 @@ public class MavenDependencyManager implements DependencyManagerWrapper {
       DependencyNode rootNode = dependencyGraphBuilder.buildDependencyGraph(buildingRequest, null);
       return new MavenDependencyGraph(project, model, rootNode);
     } catch (DependencyGraphBuilderException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -141,18 +141,18 @@ public class MavenDependencyManager implements DependencyManagerWrapper {
     File pomFile = new File(project.getBasedir().getAbsolutePath() + File.separator + "pom.xml");
 
     /* Build Maven model to manipulate the pom */
-    final Model model;
+    final Model builtModel;
     Reader reader;
     MavenXpp3Reader mavenReader = new MavenXpp3Reader();
     try {
       reader = new InputStreamReader(new FileInputStream(pomFile), StandardCharsets.UTF_8);
-      model = mavenReader.read(reader);
-      model.setPomFile(pomFile);
+      builtModel = mavenReader.read(reader);
+      builtModel.setPomFile(pomFile);
     } catch (Exception ex) {
       getLog().error("Unable to build the maven project.");
-      throw new RuntimeException(ex);
+      throw new IllegalStateException(ex);
     }
-    return model;
+    return builtModel;
   }
 
   /**
@@ -281,7 +281,7 @@ public class MavenDependencyManager implements DependencyManagerWrapper {
       return new ParsedDependencies(treeFile, analysis, classUsageFile, createCallGraphCsv)
           .parseTreeToJson();
     } catch (ParseException | IOException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 }

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
@@ -283,7 +283,7 @@ public class DepCleanMojoIT {
     log.trace("Test that DepClean creates a proper pom-debloated.xml file");
     String path =
         "target/maven-it/se/kth/depclean/DepCleanMojoIT/debloated_pom_is_correct/project/pom-debloated.xml";
-    File generated_pom_debloated = new File(path);
+    File generatedPomDebloated = new File(path);
     assertThat(result)
         .isSuccessful()
         .out()
@@ -299,9 +299,9 @@ public class DepCleanMojoIT {
             "[INFO] Excluding com.fasterxml.jackson.core:jackson-annotations from com.fasterxml.jackson.core:jackson-databind:2.22.2",
             "[INFO] POM debloated successfully",
             "[INFO] pom-debloated.xml file created in: "
-                + generated_pom_debloated.getAbsolutePath());
-    Assertions.assertTrue(generated_pom_debloated.exists());
-    assertThat(generated_pom_debloated)
+                + generatedPomDebloated.getAbsolutePath());
+    Assertions.assertTrue(generatedPomDebloated.exists());
+    assertThat(generatedPomDebloated)
         .hasSameTextualContentAs(
             new File("src/test/resources/DepCleanMojoResources/pom-debloated.xml"));
   }

--- a/depclean-maven-plugin/src/test/resources/MavenInvokerResources/basic_spring_maven_project/pom.xml
+++ b/depclean-maven-plugin/src/test/resources/MavenInvokerResources/basic_spring_maven_project/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.boot</groupId>
@@ -14,7 +16,7 @@
   <name>demo</name>
   <description>Demo project for Spring Boot</description>
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
   </properties>
   <dependencies>
     <dependency>
@@ -23,11 +25,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter-webmvc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
+      <artifactId>spring-boot-starter-webmvc-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/depclean-maven-plugin/src/test/resources/MavenInvokerResources/basic_spring_maven_project/tree_expected.txt
+++ b/depclean-maven-plugin/src/test/resources/MavenInvokerResources/basic_spring_maven_project/tree_expected.txt
@@ -14,14 +14,15 @@ com.example:demo:jar:0.0.1-SNAPSHOT
 |     +- org.springframework.boot:spring-boot:jar:4.1.1:compile
 |     |  \- org.springframework:spring-context:jar:7.0.9:compile
 |     +- org.thymeleaf:thymeleaf-spring6:jar:3.1.5.RELEASE:compile
-|     |  \- org.thymeleaf:thymeleaf:jar:3.1.5.RELEASE:compile
-|     |     +- org.attoparser:attoparser:jar:2.0.7.RELEASE:compile
-|     |     \- org.unbescape:unbescape:jar:1.1.6.RELEASE:compile
+|     |  +- org.thymeleaf:thymeleaf:jar:3.1.5.RELEASE:compile
+|     |  |  +- org.attoparser:attoparser:jar:2.0.7.RELEASE:compile
+|     |  |  \- org.unbescape:unbescape:jar:1.1.6.RELEASE:compile
+|     |  \- org.slf4j:slf4j-api:jar:2.0.18:compile
 |     \- org.springframework:spring-web:jar:7.0.9:compile
 |        +- org.springframework:spring-beans:jar:7.0.9:compile
 |        \- io.micrometer:micrometer-observation:jar:1.17.1:compile
 |           \- io.micrometer:micrometer-commons:jar:1.17.1:compile
-+- org.springframework.boot:spring-boot-starter-web:jar:4.1.1:compile
++- org.springframework.boot:spring-boot-starter-webmvc:jar:4.1.1:compile
 |  +- org.springframework.boot:spring-boot-starter-jackson:jar:4.1.1:compile
 |  |  \- org.springframework.boot:spring-boot-jackson:jar:4.1.1:compile
 |  |     \- tools.jackson.core:jackson-databind:jar:3.1.5:compile
@@ -29,7 +30,6 @@ com.example:demo:jar:0.0.1-SNAPSHOT
 |  |        \- tools.jackson.core:jackson-core:jar:3.1.5:compile
 |  +- org.springframework.boot:spring-boot-starter-tomcat:jar:4.1.1:compile
 |  |  +- org.springframework.boot:spring-boot-starter-tomcat-runtime:jar:4.1.1:compile
-|  |  |  +- org.springframework.boot:spring-boot-web-server:jar:4.1.1:compile
 |  |  |  +- org.apache.tomcat.embed:tomcat-embed-core:jar:11.0.24:compile
 |  |  |  +- org.apache.tomcat.embed:tomcat-embed-el:jar:11.0.24:compile
 |  |  |  \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:11.0.24:compile
@@ -40,36 +40,40 @@ com.example:demo:jar:0.0.1-SNAPSHOT
 |     \- org.springframework:spring-webmvc:jar:7.0.9:compile
 |        +- org.springframework:spring-aop:jar:7.0.9:compile
 |        \- org.springframework:spring-expression:jar:7.0.9:compile
-\- org.springframework.boot:spring-boot-starter-test:jar:4.1.1:test
-   +- org.springframework.boot:spring-boot-test:jar:4.1.1:test
-   +- org.springframework.boot:spring-boot-test-autoconfigure:jar:4.1.1:test
-   +- com.jayway.jsonpath:json-path:jar:2.10.0:test
-   |  \- org.slf4j:slf4j-api:jar:2.0.18:compile
-   +- jakarta.xml.bind:jakarta.xml.bind-api:jar:4.0.5:test
-   |  \- jakarta.activation:jakarta.activation-api:jar:2.1.4:test
-   +- net.minidev:json-smart:jar:2.6.0:test
-   |  \- net.minidev:accessors-smart:jar:2.6.0:test
-   |     \- org.ow2.asm:asm:jar:9.7.1:test
-   +- org.assertj:assertj-core:jar:3.27.7:test
-   |  \- net.bytebuddy:byte-buddy:jar:1.18.11:test
-   +- org.awaitility:awaitility:jar:4.3.0:test
-   +- org.hamcrest:hamcrest:jar:3.0:test
-   +- org.junit.jupiter:junit-jupiter:jar:6.0.3:test
-   |  +- org.junit.jupiter:junit-jupiter-api:jar:6.0.3:test
-   |  |  +- org.opentest4j:opentest4j:jar:1.3.0:test
-   |  |  +- org.junit.platform:junit-platform-commons:jar:6.0.3:test
-   |  |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
-   |  +- org.junit.jupiter:junit-jupiter-params:jar:6.0.3:test
-   |  \- org.junit.jupiter:junit-jupiter-engine:jar:6.0.3:test
-   |     \- org.junit.platform:junit-platform-engine:jar:6.0.3:test
-   +- org.mockito:mockito-core:jar:5.23.0:test
-   |  +- net.bytebuddy:byte-buddy-agent:jar:1.18.11:test
-   |  \- org.objenesis:objenesis:jar:3.3:test
-   +- org.mockito:mockito-junit-jupiter:jar:5.23.0:test
-   +- org.skyscreamer:jsonassert:jar:1.5.3:test
-   |  \- com.vaadin.external.google:android-json:jar:0.0.20131108.vaadin1:test
-   +- org.springframework:spring-core:jar:7.0.9:compile
-   |  +- commons-logging:commons-logging:jar:1.3.6:compile
-   |  \- org.jspecify:jspecify:jar:1.0.1:compile
-   +- org.springframework:spring-test:jar:7.0.9:test
-   \- org.xmlunit:xmlunit-core:jar:2.11.0:test
+\- org.springframework.boot:spring-boot-starter-webmvc-test:jar:4.1.1:test
+   +- org.springframework.boot:spring-boot-starter-jackson-test:jar:4.1.1:test
+   +- org.springframework.boot:spring-boot-starter-test:jar:4.1.1:test
+   |  +- org.springframework.boot:spring-boot-test:jar:4.1.1:test
+   |  +- org.springframework.boot:spring-boot-test-autoconfigure:jar:4.1.1:test
+   |  +- com.jayway.jsonpath:json-path:jar:2.10.0:test
+   |  +- jakarta.xml.bind:jakarta.xml.bind-api:jar:4.0.5:test
+   |  |  \- jakarta.activation:jakarta.activation-api:jar:2.1.4:test
+   |  +- net.minidev:json-smart:jar:2.6.0:test
+   |  |  \- net.minidev:accessors-smart:jar:2.6.0:test
+   |  |     \- org.ow2.asm:asm:jar:9.7.1:test
+   |  +- org.assertj:assertj-core:jar:3.27.7:test
+   |  |  \- net.bytebuddy:byte-buddy:jar:1.18.11:test
+   |  +- org.awaitility:awaitility:jar:4.3.0:test
+   |  +- org.hamcrest:hamcrest:jar:3.0:test
+   |  +- org.junit.jupiter:junit-jupiter:jar:6.0.3:test
+   |  |  +- org.junit.jupiter:junit-jupiter-api:jar:6.0.3:test
+   |  |  |  +- org.opentest4j:opentest4j:jar:1.3.0:test
+   |  |  |  +- org.junit.platform:junit-platform-commons:jar:6.0.3:test
+   |  |  |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
+   |  |  +- org.junit.jupiter:junit-jupiter-params:jar:6.0.3:test
+   |  |  \- org.junit.jupiter:junit-jupiter-engine:jar:6.0.3:test
+   |  |     \- org.junit.platform:junit-platform-engine:jar:6.0.3:test
+   |  +- org.mockito:mockito-core:jar:5.23.0:test
+   |  |  +- net.bytebuddy:byte-buddy-agent:jar:1.18.11:test
+   |  |  \- org.objenesis:objenesis:jar:3.3:test
+   |  +- org.mockito:mockito-junit-jupiter:jar:5.23.0:test
+   |  +- org.skyscreamer:jsonassert:jar:1.5.3:test
+   |  |  \- com.vaadin.external.google:android-json:jar:0.0.20131108.vaadin1:test
+   |  +- org.springframework:spring-core:jar:7.0.9:compile
+   |  |  +- commons-logging:commons-logging:jar:1.3.6:compile
+   |  |  \- org.jspecify:jspecify:jar:1.0.1:compile
+   |  +- org.springframework:spring-test:jar:7.0.9:test
+   |  \- org.xmlunit:xmlunit-core:jar:2.11.0:test
+   +- org.springframework.boot:spring-boot-webmvc-test:jar:4.1.1:test
+   |  \- org.springframework.boot:spring-boot-web-server:jar:4.1.1:compile
+   \- org.springframework.boot:spring-boot-resttestclient:jar:4.1.1:test


### PR DESCRIPTION
## Summary

SonarCloud reported **113 open issues** on the project. This PR fixes **~70** of them across all three modules — strictly behavior-preserving — and brings both builds to **zero warnings**.

### depclean-core
- `AbstractDebloater`: `protected` constructor (S5993)
- `ProjectDependencyAnalysisBuilder`: replaced `Stream.peek` trace-logging with a shared filter helper (S3864 ×4); also fixes a copy-paste "Transitive" label in the inherited-transitive trace log
- `ConstantPoolParser`: loop rewritten without in-body counter mutation (S127 ×2), merged the duplicated `INVOKE_DYNAMIC` case (S1871), specific exception (S112)
- `DefaultCallGraph`: private constructor (S1118)
- `DebloatedDependency`: explicit `equals`/`hashCode` delegating to super (S2160)
- `Dependency.findRelatedClasses` split into jar/directory helpers (S3776, S1117)
- `JarUtils`: entry extraction + zip-bomb checks decomposed (S3776 cc 29→<15), redundant `close()` removed (S4087)
- tests: constant/field naming (S115/S116), empty-method comments (S1186)

### depclean-maven-plugin
- `NodeAdapter`: static access to `DefaultCallGraph` (S2209)
- `MavenDependencyManager`: `IllegalStateException` instead of bare `RuntimeException` (S112 ×2), un-shadowed local (S1117)
- `MavenInvoker`: consistent mutable list returns (ErrorProne `MixedMutabilityReturnType` warning)
- `DepCleanMojoIT`: camelCase local (S117)

### depclean-gradle-plugin
- `DepCleanGradleAction.execute` (~400 lines, cognitive complexity **71**) decomposed into focused helpers with a `CoordinateSets` record (S3776), `BUILD_DIR` constant (S1192), static setter for the static map (S2696), `createNewFile` result handled (S899), `Stream.toList()` (S6204), try-with-resources for the JSON writer
- `DependencyUtils`: slf4j logger instead of `System.out` (S106 ×7), helpers extracted (S3776, S135 ×2), empty ctor removed (S1186)
- `JsonResultWriter`: stray debug `println` removed (S106)
- `GradleProjectDependencyAnalysis`: `StringBuilder.isEmpty()` (S7158 ×2)
- `DefaultGradleProjectDependencyAnalyzer`: jar-scanning helper extracted (S3776)
- `GradleWritingUtils`: private constructor (S1118)

### Analysis configuration
- New `.sonarcloud.properties` excludes the IT/FT **fixture projects** (~35 issues): default packages, commented-out code and empty test classes there are intentional test inputs, and editing them would break the size-sensitive golden assertions.

### Won't-fix (intentionally skipped)
- **S107 / S1452** (constructor parameter counts, wildcard return): require public API breaks
- **S6204 / S6206 / S6208 / S6355** in core/maven-plugin main sources: suggest Java 9+ syntax (`Stream.toList`, records, arrow switches, `@Deprecated(since)`), but main sources target **Java 8 bytecode** since #505
- **S1135** TODOs: genuine outstanding work items

### Also included
- `test:` commit refreshing `basic_spring_maven_project` fixtures (spring-boot-starter-webmvc, Java 17, current plugin snapshot) with regenerated `tree_expected.txt`, and `.gitignore` for `bin/`

## Verification
- `./mvnw clean verify`: **BUILD SUCCESS**, 0 warnings, all unit + 14 integration tests pass
- `./gradlew clean publishToMavenLocal build --warning-mode all` + `test --rerun-tasks`: **BUILD SUCCESSFUL**, 0 warnings, 18/18 tests pass

Generated by GitHub Copilot via OSS Helper