### PR TITLE
ci: verify plugin runtime on Java 8/17/21/25, fix Java 8 prerequisite, add gradle Codecov

### DIFF
--- a/.github/smoke/java8/pom.xml
+++ b/.github/smoke/java8/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Minimal Java 8 project used by CI to prove that the depclean-maven-plugin
+     built on a modern JDK actually runs on Maven with JDK 8. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>se.kth.depclean.smoke</groupId>
+    <artifactId>java8-smoke</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- used dependency -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.20.0</version>
+        </dependency>
+        <!-- unused dependency: must be reported as potentially unused -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.18.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/.github/smoke/java8/pom.xml
+++ b/.github/smoke/java8/pom.xml
@@ -22,13 +22,13 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.20.0</version>
+            <version>2.22.0</version>
         </dependency>
         <!-- unused dependency: must be reported as potentially unused -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
+            <version>3.20.0</version>
         </dependency>
     </dependencies>
 

--- a/.github/smoke/java8/src/main/java/smoke/Main.java
+++ b/.github/smoke/java8/src/main/java/smoke/Main.java
@@ -1,0 +1,12 @@
+package smoke;
+
+import java.io.File;
+import org.apache.commons.io.FileUtils;
+
+/** Uses commons-io so DepClean reports it as used; commons-lang3 stays unused. */
+public class Main {
+
+  public static void main(String[] args) {
+    System.out.println(FileUtils.byteCountToDisplaySize(new File(".").length()));
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [25]
+        include:
+          # The plugin must work on every JDK a user's Maven may run on (17+ to build;
+          # the ITs fork real mvn processes with the matrix JDK).
+          - os: ubuntu-latest
+            java: 17
+          - os: ubuntu-latest
+            java: 21
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     name: Maven Build with Java ${{ matrix.java }} on ${{ matrix.os }}
@@ -62,9 +69,62 @@ jobs:
       # so no CI-based sonar:sonar step is needed here.
 
   # --------------------------------------------------------------------------------------------------------------------
+  # The maven-plugin main sources target Java 8 bytecode (statically enforced by
+  # enforceBytecodeVersion). This job proves it at runtime: build on JDK 25, then
+  # run the depclean goal on a Java 8 fixture with Maven running on JDK 8.
+  java8-smoke:
+    name: Maven plugin smoke test on Java 8
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 8
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: 8
+          distribution: "temurin"
+
+      - name: Set up Java 25 (default)
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: 25
+          distribution: "temurin"
+          cache: "maven"
+
+      - name: "Build and install plugin (JDK 25)"
+        run: ./mvnw -ntp clean install -DskipTests -q
+
+      - name: "Resolve project version"
+        id: version
+        run: echo "version=$(./mvnw -ntp -q -DforceStdout help:evaluate -Dexpression=project.version)" >> "$GITHUB_OUTPUT"
+
+      - name: "Run DepClean on the fixture with Maven on JDK 8"
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_8_X64 }}
+        run: |
+          ./mvnw -version | grep -i 'java version: 1.8'
+          ./mvnw -ntp -f .github/smoke/java8/pom.xml \
+            package se.kth.castor:depclean-maven-plugin:${{ steps.version.outputs.version }}:depclean \
+            | tee /tmp/depclean-smoke.log
+          grep 'D E P C L E A N   A N A L Y S I S   R E S U L T S' /tmp/depclean-smoke.log
+          grep 'commons-io:commons-io' /tmp/depclean-smoke.log
+          grep 'org.apache.commons:commons-lang3' /tmp/depclean-smoke.log
+
+  # --------------------------------------------------------------------------------------------------------------------
   # For Gradle module
   gradle:
-    name: Gradle build with Java 25 on ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # JVM the plugin is verified on: the functional tests run the plugin
+        # in-process, so the test JVM is what the plugin actually executes on.
+        # The plugin targets Java 17 bytecode, hence 17 is the floor.
+        test-java: [17, 21, 25]
+    name: Gradle build with tests on Java ${{ matrix.test-java }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -90,4 +150,12 @@ jobs:
 
       - name: Build with Gradle
         working-directory: ./depclean-gradle-plugin
-        run: ./gradlew clean publishToMavenLocal build
+        run: ./gradlew clean publishToMavenLocal build -PtestJavaVersion=${{ matrix.test-java }}
+
+      - name: "Codecov (gradle plugin)"
+        if: matrix.test-java == 25 && github.repository == 'ASSERT-KTH/depclean'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./depclean-gradle-plugin/build/reports/jacoco/test/jacocoTestReport.xml
+          flags: gradleplugin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         java: [25]
         include:
-          # The plugin must work on every JDK a user's Maven may run on (17+ to build;
-          # the ITs fork real mvn processes with the matrix JDK).
-          - os: ubuntu-latest
-            java: 17
+          # Oldest JDK able to run the build toolchain (checkstyle 14 needs 21);
+          # older RUNTIME JDKs are covered by the runtime-smoke job below.
           - os: ubuntu-latest
             java: 21
     runs-on: ${{ matrix.os }}
@@ -70,10 +68,15 @@ jobs:
 
   # --------------------------------------------------------------------------------------------------------------------
   # The maven-plugin main sources target Java 8 bytecode (statically enforced by
-  # enforceBytecodeVersion). This job proves it at runtime: build on JDK 25, then
-  # run the depclean goal on a Java 8 fixture with Maven running on JDK 8.
-  java8-smoke:
-    name: Maven plugin smoke test on Java 8
+  # enforceBytecodeVersion), while the BUILD needs JDK 21+. This job proves the
+  # runtime promise: build once on JDK 25, then run the depclean goal on a
+  # Java 8 fixture with Maven running on each supported runtime JDK.
+  runtime-smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        java-runtime: [8, 17, 21, 25]
+    name: Maven plugin runtime smoke test on Java ${{ matrix.java-runtime }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -82,13 +85,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Java 8
+      - name: Set up Java ${{ matrix.java-runtime }} (runtime)
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
-          java-version: 8
+          java-version: ${{ matrix.java-runtime }}
           distribution: "temurin"
 
-      - name: Set up Java 25 (default)
+      - name: Set up Java 25 (build, default)
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: 25
@@ -102,17 +105,17 @@ jobs:
         id: version
         run: echo "version=$(./mvnw -ntp -q -DforceStdout help:evaluate -Dexpression=project.version)" >> "$GITHUB_OUTPUT"
 
-      - name: "Run DepClean on the fixture with Maven on JDK 8"
+      - name: "Run DepClean on the fixture with Maven on JDK ${{ matrix.java-runtime }}"
         env:
-          JAVA_HOME: ${{ env.JAVA_HOME_8_X64 }}
+          JAVA_HOME: ${{ env[format('JAVA_HOME_{0}_X64', matrix.java-runtime)] }}
         run: |
-          ./mvnw -version | grep -i 'java version: 1.8'
+          ./mvnw -version
           ./mvnw -ntp -f .github/smoke/java8/pom.xml \
             package se.kth.castor:depclean-maven-plugin:${{ steps.version.outputs.version }}:depclean \
             | tee /tmp/depclean-smoke.log
           grep 'D E P C L E A N   A N A L Y S I S   R E S U L T S' /tmp/depclean-smoke.log
-          grep 'commons-io:commons-io' /tmp/depclean-smoke.log
-          grep 'org.apache.commons:commons-lang3' /tmp/depclean-smoke.log
+          grep -A2 'USED DIRECT DEPENDENCIES \[1\]' /tmp/depclean-smoke.log | grep 'commons-io:commons-io'
+          grep -A2 'POTENTIALLY UNUSED DIRECT DEPENDENCIES \[1\]' /tmp/depclean-smoke.log | grep 'org.apache.commons:commons-lang3'
 
   # --------------------------------------------------------------------------------------------------------------------
   # For Gradle module

--- a/depclean-gradle-plugin/bin/main/META-INF/gradle-plugins/se.kth.castor.depCleanGradlePlugin
+++ b/depclean-gradle-plugin/bin/main/META-INF/gradle-plugins/se.kth.castor.depCleanGradlePlugin
@@ -1,0 +1,1 @@
+implementation-class = se.kth.depclean.DepCleanGradlePlugin

--- a/depclean-gradle-plugin/bin/test/se/kth/depclean/DepCleanGradleFT.groovy
+++ b/depclean-gradle-plugin/bin/test/se/kth/depclean/DepCleanGradleFT.groovy
@@ -1,0 +1,211 @@
+package se.kth.depclean
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import se.kth.depclean.util.FileUtils
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
+
+class DepCleanGradleFT extends Specification {
+
+    File emptyProjectFile = new File("src/test/resources-fts/empty_project")
+
+    def "Test that the DepClean gradle plugin runs on an empty project"() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(emptyProjectFile).build()
+
+        when:
+        project.plugins.apply("se.kth.castor.depclean-gradle-plugin")
+        // No compiled classes exist: debloat must succeed gracefully instead of
+        // crashing with "build/classes does not exist" (issue #218)
+        BuildResult debloatResult = createRunner(emptyProjectFile, "debloat")
+
+        then:
+        assert checkTaskOutcome(debloatResult.task(":debloat").getOutcome())
+    }
+
+    String projectPath1 = "src/test/resources-fts/all_dependencies_unused"
+    File allDependenciesUnused = new File(projectPath1)
+    File originalOutputFile1 = new File(projectPath1 + "/originalOutputFile.txt")
+    File expectedOutputFile1 = new File(projectPath1 + "/expectedOutputFile.txt")
+
+    def "Test that depclean gradle plugin runs on a project which has only unused dependencies"() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(allDependenciesUnused).build()
+
+        when:
+        project.plugins.apply("se.kth.castor.depclean-gradle-plugin")
+        BuildResult buildResult = createRunner(allDependenciesUnused, "build")
+        BuildResult debloatResult = createRunner(allDependenciesUnused, "debloat")
+
+        then:
+        assert checkTaskOutcome(buildResult.task(":build").getOutcome())
+        assert checkTaskOutcome(debloatResult.task(":debloat").getOutcome())
+
+        originalOutputFile1.write(debloatResult.getOutput())
+        assert compareOutputs(expectedOutputFile1, originalOutputFile1)
+        FileUtils.forceDelete(new File(projectPath1 + "/build"))
+    }
+
+    String projectPath2 = "src/test/resources-fts/all_dependencies_used"
+    File allDependenciesUsed = new File(projectPath2)
+    File originalOutputFile2 = new File(projectPath2 + "/originalOutputFile.txt")
+    File expectedOutputFile2 = new File(projectPath2 + "/expectedOutputFile.txt")
+
+    def "Test that depclean gradle plugin runs on a project which has only used dependencies"() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(allDependenciesUsed).build()
+
+        when:
+        project.plugins.apply("se.kth.castor.depclean-gradle-plugin")
+        BuildResult buildResult = createRunner(allDependenciesUsed, "build")
+        BuildResult debloatResult = createRunner(allDependenciesUsed, "debloat")
+
+        then:
+        assert checkTaskOutcome(buildResult.task(":build").getOutcome())
+        assert checkTaskOutcome(debloatResult.task(":debloat").getOutcome())
+
+        originalOutputFile2.write(debloatResult.getOutput())
+        assert compareOutputs(expectedOutputFile2, originalOutputFile2)
+        FileUtils.forceDelete(new File(projectPath2 + "/build"))
+    }
+
+    String projectPath3 = "src/test/resources-fts/debloated_dependencies.gradle_is_correct"
+    File debloatedDependenciesIsCorrect = new File(projectPath3)
+    File generatedDebloatedDependenciesDotGradle = new File(projectPath3 + "/debloated-dependencies.gradle");
+
+    def "Test that the DepClean creates a proper debloated-dependencies.gradle file"() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(debloatedDependenciesIsCorrect).build()
+
+        when:
+        project.plugins.apply("se.kth.castor.depclean-gradle-plugin")
+        BuildResult buildResult = createRunner(debloatedDependenciesIsCorrect, "build")
+        BuildResult debloatResult = createRunner(debloatedDependenciesIsCorrect, "debloat")
+
+        then:
+        assert checkTaskOutcome(buildResult.task(":build").getOutcome())
+        assert checkTaskOutcome(debloatResult.task(":debloat").getOutcome())
+
+        assert generatedDebloatedDependenciesDotGradle.exists()
+        FileUtils.forceDelete(new File(projectPath3 + "/build"))
+    }
+
+    String projectPath4 = "src/test/resources-fts/json_should_be_correct"
+    File json_should_be_correct = new File(projectPath4)
+    File generatedResultDotJson = new File(projectPath4 + "/build/depclean-results.json");
+
+    def "Test that the depclean creates a proper results.json file"() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(json_should_be_correct).build()
+
+        when:
+        project.plugins.apply("se.kth.castor.depclean-gradle-plugin")
+        BuildResult buildResult = createRunner(json_should_be_correct, "build")
+        BuildResult debloatResult = createRunner(json_should_be_correct, "debloat")
+
+        then:
+        assert checkTaskOutcome(buildResult.task(":build").getOutcome())
+        assert checkTaskOutcome(debloatResult.task(":debloat").getOutcome())
+
+        assert generatedResultDotJson.exists()
+    }
+
+    String projectPath5 = "src/test/resources-fts/multi_project"
+    File multiProject = new File(projectPath5)
+
+    def "Test that the analysis of a project does not leak into the next one"() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(multiProject).build()
+
+        when:
+        project.plugins.apply("se.kth.castor.depclean-gradle-plugin")
+        BuildResult buildResult = createRunner(multiProject, "build")
+        // Only the root task, which analyzes the root project and then its subprojects, so that the
+        // assertions below cannot be satisfied by the report of the subproject's own task.
+        BuildResult debloatResult = createRunner(multiProject, ":debloat")
+
+        then:
+        assert checkTaskOutcome(buildResult.task(":build").getOutcome())
+        assert checkTaskOutcome(debloatResult.task(":debloat").getOutcome())
+
+        // The root project uses jackson-databind, the subproject only declares it. The subproject
+        // is analyzed after the root project by the same task action, so without resetting the
+        // shared call graph the classes used by the root project are still reachable and
+        // jackson-databind is wrongly reported as used for the subproject.
+        String output = debloatResult.getOutput()
+        String subprojectReport = output.substring(output.indexOf("Analyzing subproject:"))
+        assert subprojectReport.contains("POTENTIALLY UNUSED DIRECT DEPENDENCIES [1]")
+        assert subprojectReport.contains("com.fasterxml.jackson.core:jackson-databind:2.22.2")
+
+        cleanup:
+        FileUtils.forceDelete(new File(projectPath5 + "/build"))
+        FileUtils.forceDelete(new File(projectPath5 + "/unused-subproject/build"))
+        FileUtils.forceDelete(new File(projectPath5 + "/.gradle"))
+        FileUtils.forceDelete(new File(projectPath5 + "/userHome"))
+    }
+
+    String projectPath6 = "src/test/resources-fts/xml_config_classes_used"
+    File xmlConfigClassesUsed = new File(projectPath6)
+    File originalOutputFile6 = new File(projectPath6 + "/originalOutputFile.txt")
+    File expectedOutputFile6 = new File(projectPath6 + "/expectedOutputFile.txt")
+
+    def "Test that a dependency only referenced in a Spring XML configuration is considered used"() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(xmlConfigClassesUsed).build()
+
+        when:
+        project.plugins.apply("se.kth.castor.depclean-gradle-plugin")
+        BuildResult buildResult = createRunner(xmlConfigClassesUsed, "build")
+        BuildResult debloatResult = createRunner(xmlConfigClassesUsed, "debloat")
+
+        then:
+        assert checkTaskOutcome(buildResult.task(":build").getOutcome())
+        assert checkTaskOutcome(debloatResult.task(":debloat").getOutcome())
+
+        originalOutputFile6.write(debloatResult.getOutput())
+        assert compareOutputs(expectedOutputFile6, originalOutputFile6)
+        FileUtils.forceDelete(new File(projectPath6 + "/build"))
+    }
+
+    private static BuildResult createRunner(File project, String argument) {
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(project)
+                .withArguments(argument)
+                .withDebug(true)
+                .build()
+        return result
+    }
+
+    private static boolean compareOutputs(File expectedOutputFile, File originalOutputFile) {
+
+        FileReader fileReader1 = new FileReader(expectedOutputFile)
+        FileReader fileReader2 = new FileReader(originalOutputFile)
+        BufferedReader reader1 = new BufferedReader(fileReader1)
+        BufferedReader reader2 = new BufferedReader(fileReader2)
+
+        String line1, line2
+        while (true) {
+            // Continue while there are equal lines
+            line1 = reader1.readLine()
+            line2 = reader2.readLine()
+
+            if (line1 == null) {
+                // End of file 1
+                return 1
+            }
+            if (!line1.trim().equalsIgnoreCase(line2.trim())) {
+                // Different lines, or end of file 2
+                return 0
+            }
+        }
+    }
+
+    private static boolean checkTaskOutcome(TaskOutcome outcome) {
+        return outcome == SUCCESS || outcome == UP_TO_DATE;
+    }
+}

--- a/depclean-gradle-plugin/bin/test/se/kth/depclean/utils/ClassesDirectoryFinderSpec.groovy
+++ b/depclean-gradle-plugin/bin/test/se/kth/depclean/utils/ClassesDirectoryFinderSpec.groovy
@@ -1,0 +1,162 @@
+package se.kth.depclean.utils
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class ClassesDirectoryFinderSpec extends Specification {
+
+    @TempDir
+    File projectDir
+
+    private Project buildProject(boolean withJavaPlugin = false) {
+        Project project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        if (withJavaPlugin) {
+            project.plugins.apply("java")
+        }
+        return project
+    }
+
+    private File mkdirs(String... segments) {
+        File dir = new File(projectDir, segments.join(File.separator))
+        assert dir.mkdirs() || dir.isDirectory()
+        return dir
+    }
+
+    def "returns an empty set when no class directories exist"() {
+        given:
+        Project project = buildProject()
+
+        expect:
+        ClassesDirectoryFinder.findClassesDirectories(project, false).isEmpty()
+    }
+
+    def "returns an empty set when build/classes does not exist without failing"() {
+        given: "a java project that was never compiled (issue #218 crash scenario)"
+        Project project = buildProject(true)
+
+        expect:
+        ClassesDirectoryFinder.findClassesDirectories(project, false).isEmpty()
+    }
+
+    def "finds main and test classes in the conventional JVM layout"() {
+        given:
+        Project project = buildProject(true)
+        File mainClasses = mkdirs("build", "classes", "java", "main")
+        File testClasses = mkdirs("build", "classes", "java", "test")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, false)
+
+        then:
+        result.contains(mainClasses)
+        result.contains(testClasses)
+    }
+
+    def "excludes test source sets when tests are ignored"() {
+        given:
+        Project project = buildProject(true)
+        File mainClasses = mkdirs("build", "classes", "java", "main")
+        File testClasses = mkdirs("build", "classes", "java", "test")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, true)
+
+        then:
+        result.contains(mainClasses)
+        !result.contains(testClasses)
+    }
+
+    def "finds groovy and kotlin classes in the conventional layout"() {
+        given:
+        Project project = buildProject()
+        File groovyClasses = mkdirs("build", "classes", "groovy", "main")
+        File kotlinClasses = mkdirs("build", "classes", "kotlin", "main")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, false)
+
+        then:
+        result.containsAll([groovyClasses, kotlinClasses])
+    }
+
+    def "finds custom source set output directories"() {
+        given:
+        Project project = buildProject(true)
+        project.sourceSets.create("integration")
+        File integrationClasses = mkdirs("build", "classes", "java", "integration")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, false)
+
+        then:
+        result.contains(integrationClasses)
+    }
+
+    def "finds Android javac classes for multiple product flavors"() {
+        given: "the Android layout reported in issue #218"
+        Project project = buildProject()
+        File devDebug = mkdirs("build", "intermediates", "javac", "devDebug", "classes")
+        File prodRelease = mkdirs("build", "intermediates", "javac", "prodRelease", "classes")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, false)
+
+        then:
+        result.containsAll([devDebug, prodRelease])
+    }
+
+    def "excludes Android test variants when tests are ignored"() {
+        given:
+        Project project = buildProject()
+        File devDebug = mkdirs("build", "intermediates", "javac", "devDebug", "classes")
+        File unitTest = mkdirs("build", "intermediates", "javac", "devDebugUnitTest", "classes")
+        File androidTest = mkdirs("build", "intermediates", "javac", "devDebugAndroidTest", "classes")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, true)
+
+        then:
+        result.contains(devDebug)
+        !result.contains(unitTest)
+        !result.contains(androidTest)
+    }
+
+    def "includes Android test variants when tests are not ignored"() {
+        given:
+        Project project = buildProject()
+        File unitTest = mkdirs("build", "intermediates", "javac", "devDebugUnitTest", "classes")
+
+        expect:
+        ClassesDirectoryFinder.findClassesDirectories(project, false).contains(unitTest)
+    }
+
+    def "finds Android kotlin classes per variant"() {
+        given:
+        Project project = buildProject()
+        File debug = mkdirs("build", "tmp", "kotlin-classes", "debug")
+        File releaseTest = mkdirs("build", "tmp", "kotlin-classes", "debugUnitTest")
+
+        when:
+        Set<File> resultWithTests = ClassesDirectoryFinder.findClassesDirectories(project, false)
+        Set<File> resultWithoutTests = ClassesDirectoryFinder.findClassesDirectories(project, true)
+
+        then:
+        resultWithTests.containsAll([debug, releaseTest])
+        resultWithoutTests.contains(debug)
+        !resultWithoutTests.contains(releaseTest)
+    }
+
+    def "does not duplicate directories reported by both source sets and layout scan"() {
+        given:
+        Project project = buildProject(true)
+        File mainClasses = mkdirs("build", "classes", "java", "main")
+
+        when:
+        Set<File> result = ClassesDirectoryFinder.findClassesDirectories(project, false)
+
+        then:
+        result.count { it == mainClasses } == 1
+    }
+}

--- a/depclean-gradle-plugin/build.gradle
+++ b/depclean-gradle-plugin/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.diffplug.spotless' version '8.10.0'
     id 'groovy'
+    id 'jacoco'
     id 'java'
     id 'java-gradle-plugin'
     id 'jvm-test-suite'
@@ -17,6 +18,12 @@ java {
 
 tasks.withType(JavaCompile).configureEach {
     options.release = 17
+}
+
+// Groovy (Spock) test classes must also run on the Java 17 test launcher
+tasks.withType(GroovyCompile).configureEach {
+    sourceCompatibility = '17'
+    targetCompatibility = '17'
 }
 
 group = 'se.kth.castor'
@@ -63,12 +70,29 @@ testing {
 }
 
 tasks.withType(Test).configureEach {
+    // The functional tests run the plugin in-process, so the test JVM is the JVM
+    // the plugin is verified on. -PtestJavaVersion=17|21|25 selects it (CI matrix).
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of((findProperty('testJavaVersion') ?: '21') as int)
+    }
     // Show full exception detail on CI, where the HTML report is not accessible
     testLogging {
         exceptionFormat 'full'
         showExceptions true
         showCauses true
         showStackTraces true
+    }
+    finalizedBy tasks.named('jacocoTestReport')
+}
+
+jacoco {
+    toolVersion = '0.8.15'
+}
+
+tasks.named('jacocoTestReport', JacocoReport) {
+    dependsOn tasks.named('test')
+    reports {
+        xml.required = true
     }
 }
 

--- a/depclean-gradle-plugin/settings.gradle
+++ b/depclean-gradle-plugin/settings.gradle
@@ -1,2 +1,7 @@
+plugins {
+    // Auto-provisions toolchain JDKs that are not preinstalled on the machine
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
 rootProject.name = 'depclean-gradle-plugin'
 

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -209,6 +209,10 @@
         <configuration>
           <goalPrefix>depclean</goalPrefix>
           <skipErrorNoDescriptorsFound>false</skipErrorNoDescriptorsFound>
+          <!-- The runtime floor is Java 8 (main sources emit Java 8 bytecode);
+               without this, the plugin-plugin derives 17 from the enforcer's
+               requireJavaVersion, which is only the BUILD requirement. -->
+          <requiredJavaVersion>${java.version}</requiredJavaVersion>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
## Summary

Answers two CI gaps: **no Codecov for the gradle module** and **no verification that the plugins actually run on all supported JDKs** — and fixes a real bug the new smoke test caught immediately.

## 🐛 Bug fix: the plugin refused to run on JDK 8-16

`maven-plugin-plugin` 3.8+ auto-derives `requiredJavaVersion` from the enforcer's `requireJavaVersion [17,)` — which is only the **build** requirement. The published descriptor therefore declared Java 17, and Maven failed with *"unmet prerequisites: Required Java version 17"* on JDK 8, defeating the Java 8 bytecode work from #505. Now pinned to `${java.version}` (8).

## Why not simply `java: [8, 17, 21, 25]` in the build matrix?

The **build** and the **runtime** have different JDK floors, so a plain matrix can't work:
- JDK 8: tests compile to release 17 → cannot build at all
- JDK 17: checkstyle 14 ships Java 21 classfiles → build fails (verified locally)
- The gradle plugin targets Java 17 bytecode → Java 8 is out of scope for it by design

So the coverage is split into three mechanisms:

### 1. `runtime-smoke` job — Maven plugin on Java 8/17/21/25 (the real ask)
Builds the plugin once on JDK 25, then runs `depclean:depclean` on a tiny Java 8 fixture (`.github/smoke/java8`) with **Maven actually running on each runtime JDK**, asserting the banner and the used/unused categorization (`commons-io` used, `commons-lang3` unused).

### 2. Maven build matrix gains JDK 21
`ubuntu × 21` added next to the existing 3-OS × 25 — 21 is the lowest JDK that can run the build toolchain. The ITs fork real `mvn` processes on the matrix JDK.

### 3. Gradle job becomes a test-JVM matrix (17/21/25)
The FTs run the plugin **in-process** (`GradleRunner.withDebug(true)`), so the test JVM is the JVM the plugin executes on. A new `-PtestJavaVersion` property pins the test launcher toolchain (default 21). Supporting changes: Groovy/Spock test classes now compile to Java 17 (they were Java 21 classfiles and crashed the 17 launcher), and the foojay resolver auto-provisions missing toolchains.

## Codecov for the gradle module
JaCoCo (0.8.15, XML report) wired into the gradle build and uploaded with a new `gradleplugin` flag on the Java 25 leg. ⚠️ Known limitation: TestKit-loaded plugin classes are only partially attributed (~7% line coverage today — mostly the unit specs); the wiring is in place and can be improved later by attaching the agent to TestKit daemons.

## Verification (all local)
- JDK 8 smoke: **BUILD SUCCESS**, correct used/unused report (previously failed with the prerequisite error)
- JDK 17 smoke: **BUILD SUCCESS**
- `./mvnw clean verify` on JDK 21 and 25: **BUILD SUCCESS**
- `./gradlew build -PtestJavaVersion=17` and `=25`: **BUILD SUCCESSFUL**, 18/18 tests, JaCoCo XML produced
- JDK 17 full build: fails on checkstyle 14 (documented rationale for the 21 floor)

Generated by GitHub Copilot via OSS Helper