### PR TITLE
perf: run the Maven plugin ITs in parallel (~2 min → ~30 s)

### DIFF
--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -162,6 +162,17 @@
           <includes>
             <include>**/*IT.java</include>
           </includes>
+          <!-- Each IT forks an isolated mvn build (own project dir, own local repo, own
+               target), so they are safe to run concurrently; threads mostly wait on the
+               forked process, hence a parallelism above the core count. -->
+          <properties>
+            <configurationParameters>
+              junit.jupiter.execution.parallel.enabled = true
+              junit.jupiter.execution.parallel.mode.default = concurrent
+              junit.jupiter.execution.parallel.config.strategy = fixed
+              junit.jupiter.execution.parallel.config.fixed.parallelism = 6
+            </configurationParameters>
+          </properties>
           <!-- Instrument the Maven processes forked by the ITs with the JaCoCo agent -->
           <environmentVariables>
             <MAVEN_OPTS>${itCoverageAgent}</MAVEN_OPTS>


### PR DESCRIPTION
## Summary

Investigation of slow CI jobs showed `DepCleanMojoIT` is the dominant cost of every Maven job: **125 s on ubuntu, 105 s on macos, 240 s on windows** (windows being the wall-time bound of the whole workflow). The 12 active ITs each fork a full `mvn` build and ran strictly sequentially.

## Change

Enable JUnit 5 parallel execution for failsafe (`fixed` strategy, parallelism 6). This is safe because itf gives every `@MavenTest` a fully isolated forked build:
- own copied project directory (`target/maven-it/.../<test>/`)
- own local repository (`<test>/.m2/repository`)
- own `target/` (incl. the `dependency/` extraction dir)

Parallelism 6 > core count is intentional — the test threads mostly block waiting on the forked `mvn` process.

`MavenInvokerTest` (the #2 hotspot, 25–40 s) was deliberately **not** parallelized: its tests share one fixture directory and output file.

## Verification (local, 2 full `./mvnw clean verify` runs)

- `DepCleanMojoIT`: 30.4 s / 27.2 s (12 run, 2 skipped, 0 failures both runs)
- JaCoCo IT coverage identical to the sequential baseline (11 classes / 408 lines covered) — the agent file-locks `jacoco-it.exec`, so concurrent forks append safely

Generated by GitHub Copilot via OSS Helper