### PR TITLE
ci: split Codecov reporting into per-module components

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,37 @@ coverage:
   range: "70...100"
   status:
     patch: off
+    project:
+      default:
+        # The repo total mixes modules with very different coverage levels
+        # (the gradle plugin starts low), so gate on "no regression" instead
+        # of an absolute target.
+        target: auto
+        threshold: 1%
+
+# Uploads come from three CI jobs; carryforward keeps a flag's last known
+# coverage when a job does not re-upload, so one job can never "erase"
+# another module's data from the merged report.
+flag_management:
+  default_rules:
+    carryforward: true
+
+# Per-module breakdown, so maven and gradle coverage are visible side by
+# side instead of a single diluted repo total.
+component_management:
+  individual_components:
+    - component_id: core
+      name: depclean-core
+      paths:
+        - depclean-core/**
+    - component_id: maven-plugin
+      name: depclean-maven-plugin
+      paths:
+        - depclean-maven-plugin/**
+    - component_id: gradle-plugin
+      name: depclean-gradle-plugin
+      paths:
+        - depclean-gradle-plugin/**
 
 parsers:
   gcov:
@@ -17,7 +48,7 @@ parsers:
       macro: no
 
 comment:
-  layout: "reach,diff,footer"
+  layout: "reach,diff,flags,components,footer"
   behavior: default
   require_changes: true  # Only post the comment if coverage changes
   require_base: yes        # Must have a base report to post


### PR DESCRIPTION
## Summary

Follow-up to #514. The gradle Codecov upload appears to "override" the maven data — it does **not**. Verified via the Codecov API that the reports merge exactly:

| | before #514 | after #514 |
|---|---|---|
| lines | 1861 | 2781 (= 1861 + gradle's 920) |
| hits | 1412 | 1474 (= 1412 + gradle's 62) |
| total | **75.87%** | **53.0%** |

Per-flag data is intact: `unittests` 75.87%, `integration` 75.87%, `gradleplugin` 6.74%. The repo total simply got **diluted** by the low-covered gradle module, which reads like an override on the dashboard.

## Changes (codecov.yml)

- **`component_management`**: `depclean-core`, `depclean-maven-plugin`, `depclean-gradle-plugin` reported side by side — the maven numbers stay visible at their real level
- **PR comment layout** gains `flags` and `components` sections
- **`flag_management.carryforward: true`**: a CI job that doesn't re-upload can never drop its module from the merged report
- **project status → `target: auto, threshold: 1%`**: gate on regression instead of an absolute range the mixed total can no longer meet

Config validated against `https://codecov.io/validate` ✅

The real fix for the gradle number itself (TestKit-loaded classes not attributed by JaCoCo, ~7% today) remains the known follow-up from #514.

Generated by GitHub Copilot via OSS Helper