### PR TITLE
#522 Publish to Maven Central via the Central Publisher Portal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Approval in this environment is restricted to maintainers, so a release cannot start
-    # until one of them signs it off.
+    # Run in the `release` environment. Configure that environment with required reviewers (maintainers)
+    # so a manual `workflow_dispatch` release pauses for approval before publishing.
     environment: release
     permissions:
       contents: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Approval in this environment is restricted to maintainers, so a release cannot start
+    # until one of them signs it off.
+    environment: release
     permissions:
       contents: write
     steps:
@@ -45,7 +48,7 @@ jobs:
           distribution: "temurin"
           java-version: 25
           cache: "maven"
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -64,8 +67,8 @@ jobs:
       - name: Release Maven package
         run: ./mvnw -ntp --batch-mode clean deploy -P deploy -Djacoco.skip=true -DskipTests
         env:
-          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Create and push tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Please follow the checklist in the [pull request template](.github/PULL_REQUEST_
 
 ## Releasing (maintainers only)
 
-Releases are published to Maven Central through the [Central Publisher Portal](https://central.sonatype.org/publish/publish-portal-maven/) by the [Deploy workflow](.github/workflows/deploy.yml).
+Releases are published to Maven Central through the [Central Publisher Portal](https://central.sonatype.com) (see the [Sonatype Maven guide](https://central.sonatype.org/publish/publish-portal-maven/)) by the [Deploy workflow](.github/workflows/deploy.yml).
 
 1. Bump the version in `pom.xml` to the release version and merge it to `master`.
 2. Run the **Deploy** workflow manually (Actions → Deploy → Run workflow), passing the previous and new versions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,25 @@ Please follow the checklist in the [pull request template](.github/PULL_REQUEST_
 3. Reference the related issue in the PR title and description, and summarize your changes in bullet points.
 4. Be ready to discuss your changes during code review.
 
+## Releasing (maintainers only)
+
+Releases are published to Maven Central through the [Central Publisher Portal](https://central.sonatype.org/publish/publish-portal-maven/) by the [Deploy workflow](.github/workflows/deploy.yml).
+
+1. Bump the version in `pom.xml` to the release version and merge it to `master`.
+2. Run the **Deploy** workflow manually (Actions → Deploy → Run workflow), passing the previous and new versions.
+3. The run pauses until a maintainer approves it in the `release` environment, then it signs the artifacts, publishes them, tags the commit, and opens a draft GitHub release.
+
+The workflow needs these repository secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `CENTRAL_TOKEN_USERNAME` | Username part of the Central Portal [user token](https://central.sonatype.org/publish/generate-portal-token/) |
+| `CENTRAL_TOKEN_PASSWORD` | Password part of the Central Portal user token |
+| `GPG_PRIVATE_KEY` | Private key used to sign the artifacts |
+| `GPG_PASSPHRASE` | Passphrase of that key |
+
+Central no longer accepts a Sonatype account password for publishing, so the token has to be regenerated from the Portal when it is rotated or revoked.
+
 ## Reporting bugs and requesting features
 
 Use the [issue tracker](https://github.com/ASSERT-KTH/depclean/issues) with the provided templates. For security vulnerabilities, please follow the [security policy](SECURITY.md) instead of opening a public issue.

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <spotbugs-annotations.version>4.10.4</spotbugs-annotations.version>
 
     <!-- Plugins -->
+    <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.16.0</maven-compiler-plugin.version>
@@ -49,7 +50,6 @@
     <maven-site-plugin.version>3.22.0</maven-site-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
-    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
     <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
     <spotless-maven-plugin.version>3.10.1</spotless-maven-plugin.version>
 
@@ -325,14 +325,12 @@
     <url>https://github.com/castor-software/depclean/issues</url>
   </issueManagement>
 
+  <!-- Releases are published to Maven Central through the Central Publisher Portal, which the
+       central-publishing-maven-plugin below drives via its API rather than a deploy repository. -->
   <distributionManagement>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
 
@@ -374,21 +372,22 @@
             </executions>
           </plugin>
 
-          <!-- Nexus Staging Maven plugin for deployment to Sonatype-->
+          <!-- Central Publishing Maven plugin to publish to Maven Central via the Portal -->
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${central-publishing-maven-plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+              <deploymentName>depclean ${project.version}</deploymentName>
             </configuration>
           </plugin>
 
           <!-- Performing a release deployment with the Maven Release Plugin -->
-          <!-- see https://central.sonatype.org/pages/apache-maven.html -->
+          <!-- see https://central.sonatype.org/publish/publish-portal-maven/ -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
#522

Migrates Maven Central publishing off the sunset OSSRH Nexus instance (`oss.sonatype.org`) onto the Central Publisher Portal, which requires a user token instead of an account username/password.

Changes:

* `pom.xml`: replace `org.sonatype.plugins:nexus-staging-maven-plugin` with `org.sonatype.central:central-publishing-maven-plugin` (0.11.0) in the `deploy` profile, configured with `publishingServerId=central`, `autoPublish=true` and `waitUntil=published` so a CI release is fully published without manual intervention in the Portal UI.
* `pom.xml`: drop the OSSRH staging `<repository>` from `distributionManagement` (the plugin publishes through the Portal API, not a deploy repository) and repoint `<snapshotRepository>` at `https://central.sonatype.com/repository/maven-snapshots/`.
* `pom.xml`: remove the now-unused `nexus-staging-maven-plugin.version` property and refresh the stale doc link on the release plugin.
* `.github/workflows/deploy.yml`: switch `server-id` to `central` and read the credentials from new `CENTRAL_TOKEN_USERNAME` / `CENTRAL_TOKEN_PASSWORD` secrets instead of `NEXUS_USERNAME` / `NEXUS_PASSWORD`.
* `.github/workflows/deploy.yml`: put the release job in a `release` environment, so a manual `workflow_dispatch` run pauses for maintainer approval before publishing.
* `CONTRIBUTING.md`: document the release procedure and the secrets it needs.

GPG signing (`maven-gpg-plugin`) is unchanged — Central still requires signed artifacts.

Verification:

* `mvn clean verify` passes.
* `mvn deploy -P deploy -DskipPublishing=true -Dgpg.skip=true` runs the `central-publishing:0.11.0:publish (injected-central-publishing)` goal in all three modules, confirming the extension binds correctly.
* `mvn help:effective-pom -P deploy` shows no remaining `oss.sonatype.org` or `nexus-staging` references.

Follow-up needed before the next release (cannot be done in this PR):

1. Generate a Central Portal user token and add `CENTRAL_TOKEN_USERNAME` / `CENTRAL_TOKEN_PASSWORD` as repository secrets; the old `NEXUS_*` secrets can then be deleted.
2. Create the `release` environment with required reviewers limited to maintainers.

JReleaser was considered as mentioned in the issue, but it would replace the signing, publishing and GitHub-release steps in one go and is better evaluated separately once this pipeline is proven working.
