### PR TITLE
chore: release version 2.2.0

### DIFF
--- a/depclean-core/pom.xml
+++ b/depclean-core/pom.xml
@@ -8,12 +8,12 @@
   <parent>
     <groupId>se.kth.castor</groupId>
     <artifactId>depclean-parent-pom</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0</version>
   </parent>
 
   <!-- Coordinates -->
   <artifactId>depclean-core</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.2.0</version>
 
   <packaging>jar</packaging>
 

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -8,12 +8,12 @@
   <parent>
     <groupId>se.kth.castor</groupId>
     <artifactId>depclean-parent-pom</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0</version>
   </parent>
 
   <!-- Coordinates -->
   <artifactId>depclean-maven-plugin</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.2.0</version>
 
   <packaging>maven-plugin</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <!-- Coordinates -->
   <groupId>se.kth.castor</groupId>
   <artifactId>depclean-parent-pom</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.2.0</version>
   <packaging>pom</packaging>
 
   <!-- Name of the parent module -->
@@ -59,7 +59,7 @@
     <java.version>8</java.version>
     <java.test.version>17</java.test.version>
     <linkXRef>false</linkXRef>
-    <project.build.outputTimestamp>2026-08-22T00:00:00Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-09-04T13:25:46Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>


### PR DESCRIPTION
Bumps the Maven reactor version from `2.2.0-SNAPSHOT` to `2.2.0` in `pom.xml`, `depclean-core/pom.xml`, and `depclean-maven-plugin/pom.xml` via `mvn versions:set`, in preparation for the Maven Central release via the [Deploy workflow](.github/workflows/deploy.yml) (see #523).

After this merges, run **Actions → Deploy → Run workflow** on `master` with `previousVersion=2.1.0`, `newVersion=2.2.0`.