### PR TITLE
test: align expected Lombok version with 1.18.48 bump

### DIFF
--- a/depclean-gradle-plugin/README.md
+++ b/depclean-gradle-plugin/README.md
@@ -29,7 +29,7 @@ Then add the plugin to your `build.gradle` file:
 
 ```groovy
 plugins {
-    id 'se.kth.castor.depclean-gradle-plugin' version '2.2.0-SNAPSHOT'
+    id 'se.kth.castor.depclean-gradle-plugin' version '2.2.0'
 }
 ```
 Then, you can run the `debloat` task to analyze your project and remove unused dependencies:

--- a/depclean-gradle-plugin/build.gradle
+++ b/depclean-gradle-plugin/build.gradle
@@ -27,7 +27,7 @@ tasks.withType(GroovyCompile).configureEach {
 }
 
 group = 'se.kth.castor'
-version = '2.2.0-SNAPSHOT'
+version = '2.2.0'
 
 repositories {
   mavenLocal()
@@ -35,7 +35,7 @@ repositories {
 }
 
 ext {
-    depcleanVersion = '2.2.0-SNAPSHOT'
+    depcleanVersion = '2.2.0'
     errorProneCoreVersion = '2.50.0'
     jspecifyVersion = '1.0.1'
     nullawayVersion = '0.14.1'

--- a/depclean-gradle-plugin/src/test/resources-fts/all_dependencies_unused/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/all_dependencies_unused/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0-SNAPSHOT'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/all_dependencies_used/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/all_dependencies_used/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0-SNAPSHOT'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/debloated_dependencies.gradle_is_correct/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/debloated_dependencies.gradle_is_correct/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0-SNAPSHOT'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/empty_project/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/empty_project/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0-SNAPSHOT'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/json_should_be_correct/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/json_should_be_correct/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0-SNAPSHOT'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/multi_project/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/multi_project/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0-SNAPSHOT'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/xml_config_classes_used/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/xml_config_classes_used/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0-SNAPSHOT'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
     }
 }
 

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
@@ -190,7 +190,7 @@ public class DepCleanMojoIT {
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",
             "-------------------------------------------------------",
             "USED DIRECT DEPENDENCIES [5]: ",
-            "	org.projectlombok:lombok:1.18.46:compile (1 MB)",
+            "	org.projectlombok:lombok:1.18.48:compile (1 MB)",
             "	org.apache.commons:commons-lang3:3.20.0:compile (697 KB)",
             "	commons-io:commons-io:2.22.0:compile (594 KB)",
             "	commons-codec:commons-codec:1.22.1:compile (412 KB)",


### PR DESCRIPTION
#529 bumped Lombok to `1.18.48` in the `all_dependencies_used` IT fixture pom, but the expected DepClean output hard-coded in `DepCleanMojoIT` still listed `1.18.46`. Every job of [run 34016246157](https://github.com/ASSERT-KTH/depclean/actions/runs/34016246157) fails in `DepCleanMojoIT.all_dependencies_used` because of this.

Changes:

- `DepCleanMojoIT.java`: expected line `org.projectlombok:lombok:1.18.46:compile (1 MB)` → `1.18.48` (size unchanged, matches the CI output)

Verification:

- `./mvnw -ntp clean verify -Dtest=NONE -Dsurefire.failIfNoSpecifiedTests=false -Dit.test=DepCleanMojoIT#all_dependencies_used` → `Tests run: 1, Failures: 0`, `BUILD SUCCESS`