### PR TITLE
build: add version-sync and release scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,29 @@ jobs:
           grep -A2 'POTENTIALLY UNUSED DIRECT DEPENDENCIES \[1\]' /tmp/depclean-smoke.log | grep 'org.apache.commons:commons-lang3'
 
   # --------------------------------------------------------------------------------------------------------------------
+  # The Gradle plugin, its test fixtures and the READMEs carry the version as a literal;
+  # this fails fast when any of them drifts from pom.xml (see scripts/set-version.sh).
+  version-consistency:
+    name: Version references match pom.xml
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 25
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: 25
+          distribution: "temurin"
+          cache: "maven"
+
+      - name: "Check version references"
+        run: scripts/set-version.sh --check
+
+  # --------------------------------------------------------------------------------------------------------------------
   # For Gradle module
   gradle:
     strategy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,12 +89,12 @@ jobs:
           draft: true
           prerelease: false
 
+      # Safety net: the release PR (scripts/release.sh prepare) already updates the README.
       - name: Update README
         env:
-          PREVIOUS_VERSION: ${{ github.event.inputs.previousVersion }}
           NEW_VERSION: ${{ github.event.inputs.newVersion }}
         run: |
-          sed -i "s/version>$PREVIOUS_VERSION<\/version/version>$NEW_VERSION<\/version/g" README.md
+          scripts/set-version.sh --readme-only "$NEW_VERSION"
           git add README.md
           if git diff --cached --quiet; then
             echo "README already up to date, nothing to commit"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,15 @@ Please follow the checklist in the [pull request template](.github/PULL_REQUEST_
 
 Releases are published to Maven Central through the [Central Publisher Portal](https://central.sonatype.com) (see the [Sonatype Maven guide](https://central.sonatype.org/publish/publish-portal-maven/)) by the [Deploy workflow](.github/workflows/deploy.yml).
 
-1. Bump the version in `pom.xml` to the release version and merge it to `master`.
-2. Run the **Deploy** workflow manually (Actions → Deploy → Run workflow), passing the previous and new versions.
-3. The run pauses until a maintainer approves it in the `release` environment, then it signs the artifacts, publishes them, tags the commit, and opens a draft GitHub release.
+The version is carried not only by the Maven POMs but also by the Gradle plugin, its test fixtures and the READMEs. `scripts/set-version.sh <version>` updates all of them at once, and CI fails if any of them drifts from `pom.xml` (`scripts/set-version.sh --check`). Never bump versions by hand.
+
+`scripts/release.sh` drives the release from a clean, up-to-date `master` checkout (needs an authenticated `gh`):
+
+1. `scripts/release.sh prepare X.Y.Z` — bumps every version reference, runs a sanity build and opens the release PR. Review and merge it.
+2. `scripts/release.sh publish X.Y.Z` — dispatches the **Deploy** workflow on `master` and waits for it. The run pauses until a maintainer approves it in the `release` environment, then it signs the artifacts, publishes them, tags the commit, and opens a draft GitHub release.
+3. `scripts/release.sh finish X.Y.Z` — waits for the artifacts to appear on Maven Central, publishes the draft GitHub release and opens the PR that bumps `master` to the next `-SNAPSHOT`.
+
+Every step checks its preconditions and can be re-run; add `--dry-run` to see what a step would do.
 
 The workflow needs these repository secrets:
 

--- a/depclean-core/src/test/resources/basic_spring_maven_project/pom.xml
+++ b/depclean-core/src/test/resources/basic_spring_maven_project/pom.xml
@@ -45,7 +45,7 @@
         <!-- see https://github.com/castor-software/depclean -->
         <groupId>se.kth.castor</groupId>
         <artifactId>depclean-maven-plugin</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.0</version>
         <executions>
           <execution>
             <goals>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# Drives a DepClean release end to end, one step at a time.
+#
+#   scripts/release.sh prepare <X.Y.Z>   bump every version reference, sanity-build, open the release PR
+#   scripts/release.sh publish <X.Y.Z>   dispatch the Deploy workflow on master and wait for it
+#   scripts/release.sh finish  <X.Y.Z>   publish the draft GitHub release, open the next-SNAPSHOT PR
+#
+# Options:  --dry-run   print the commands that would change something instead of running them
+# Env:      DEPCLEAN_REPO   GitHub repository to release from (default: ASSERT-KTH/depclean)
+#
+# Flow: prepare -> merge the PR -> publish -> approve the run in the `release`
+# environment -> finish. Each step checks its own preconditions and can be re-run.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+REPO=${DEPCLEAN_REPO:-ASSERT-KTH/depclean}
+REPO_URL="https://github.com/$REPO.git"
+CENTRAL_BASE="https://repo1.maven.org/maven2/se/kth/castor/depclean-maven-plugin"
+RELEASE_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+DRY_RUN=0
+
+die()  { echo "error: $*" >&2; exit 1; }
+info() { echo "==> $*"; }
+
+# run <cmd...>: executes, or only prints under --dry-run
+run() {
+  if [[ $DRY_RUN -eq 1 ]]; then
+    printf '[dry-run]'; printf ' %q' "$@"; echo
+  else
+    "$@"
+  fi
+}
+
+need() { command -v "$1" >/dev/null || die "'$1' is required"; }
+
+pom_version() {
+  ./mvnw -ntp -q help:evaluate -Dexpression=project.version -DforceStdout
+}
+
+# Owner of the `origin` remote; PR heads are pushed there (fork or upstream alike).
+origin_owner() {
+  git remote get-url origin | sed -E 's#^.*github\.com[:/]([^/]+)/.*$#\1#'
+}
+
+require_clean_master() {
+  [[ -z "$(git status --porcelain)" ]] || die "working tree is not clean"
+  [[ "$(git branch --show-current)" == master ]] || die "must be on master"
+  git fetch --quiet "$REPO_URL" master
+  [[ "$(git rev-parse HEAD)" == "$(git rev-parse FETCH_HEAD)" ]] \
+    || die "local master differs from $REPO master; sync first (git merge --ff-only FETCH_HEAD)"
+}
+
+# open_pr <branch> <title> <body>
+open_pr() {
+  local branch=$1 title=$2 body=$3
+  run git push --set-upstream origin "$branch"
+  run gh pr create --repo "$REPO" --base master --head "$(origin_owner):$branch" \
+    --title "$title" --body "$body"
+}
+
+next_snapshot() {
+  local IFS=. ; read -r major minor patch <<<"$1"
+  echo "$major.$minor.$((patch + 1))-SNAPSHOT"
+}
+
+# ---------------------------------------------------------------------------
+
+cmd_prepare() {
+  local v=$1
+  local branch="release/$v"
+  require_clean_master
+  ! git rev-parse -q --verify "refs/heads/$branch" >/dev/null || die "branch $branch already exists"
+  ! gh release view "$v" --repo "$REPO" >/dev/null 2>&1 || die "release $v already exists on $REPO"
+
+  info "bumping all version references to $v"
+  run git switch -c "$branch"
+  run scripts/set-version.sh "$v"
+
+  info "sanity build (no tests)"
+  run ./mvnw -ntp -q clean install -DskipTests
+  run ./depclean-gradle-plugin/gradlew -p depclean-gradle-plugin -q build -x test
+
+  run git add -A
+  run git commit -m "release: bump version to $v"
+  open_pr "$branch" "release: bump version to $v" \
+"Prepares the $v release: every version reference is set to \`$v\` via \`scripts/set-version.sh\`.
+
+After merging, run \`scripts/release.sh publish $v\`."
+}
+
+cmd_publish() {
+  local v=$1 prev run_id url
+  require_clean_master
+  [[ "$(pom_version)" == "$v" ]] || die "master pom.xml is at $(pom_version), not $v; merge the release PR first"
+  ! git ls-remote --exit-code --tags "$REPO_URL" "refs/tags/$v" >/dev/null || die "tag $v already exists on $REPO"
+  prev=$(gh release list --repo "$REPO" --exclude-drafts --exclude-pre-releases --limit 1 \
+         --json tagName --jq '.[0].tagName')
+  [[ -n "$prev" ]] || die "could not determine previous release"
+  info "dispatching Deploy on $REPO master: previousVersion=$prev newVersion=$v"
+  run gh workflow run deploy.yml --repo "$REPO" --ref master -f previousVersion="$prev" -f newVersion="$v"
+  [[ $DRY_RUN -eq 0 ]] || return 0
+
+  sleep 10
+  run_id=$(gh run list --repo "$REPO" --workflow deploy.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+  url=$(gh run view "$run_id" --repo "$REPO" --json url --jq .url)
+  info "run started: $url"
+  info "approve it in the 'release' environment when prompted; waiting for completion..."
+  if gh run watch "$run_id" --repo "$REPO" --exit-status >/dev/null 2>&1; then
+    info "Deploy succeeded. Next: scripts/release.sh finish $v"
+  else
+    die "Deploy run failed or was cancelled: $url"
+  fi
+}
+
+cmd_finish() {
+  local v=$1 next branch
+  need curl
+  info "waiting for $v on Maven Central"
+  local i
+  for ((i = 0; i < 60; i++)); do
+    curl -fsIL "$CENTRAL_BASE/$v/depclean-maven-plugin-$v.pom" -o /dev/null && break
+    [[ $DRY_RUN -eq 0 ]] || break
+    sleep 60
+  done
+  ((i < 60)) || die "$v not visible on Maven Central after 60 minutes"
+
+  info "publishing draft GitHub release $v"
+  run gh release edit "$v" --repo "$REPO" --draft=false --latest
+
+  # Deploy pushed a README commit to master, so re-sync before branching.
+  [[ -z "$(git status --porcelain)" ]] || die "working tree is not clean"
+  [[ "$(git branch --show-current)" == master ]] || die "must be on master"
+  git fetch --quiet "$REPO_URL" master
+  run git merge --ff-only FETCH_HEAD
+
+  next=$(next_snapshot "$v")
+  branch="chore/next-snapshot-$next"
+  info "bumping to $next"
+  run git switch -c "$branch"
+  run scripts/set-version.sh "$next"
+  run git add -A
+  run git commit -m "chore: bump version to $next"
+  open_pr "$branch" "chore: bump version to $next" \
+"Post-release housekeeping after $v: all version references move to \`$next\` via \`scripts/set-version.sh\`."
+}
+
+# ---------------------------------------------------------------------------
+
+args=()
+for a in "$@"; do
+  case "$a" in
+    --dry-run) DRY_RUN=1 ;;
+    *) args+=("$a") ;;
+  esac
+done
+set -- "${args[@]+"${args[@]}"}"
+
+cmd=${1:-}
+version=${2:-}
+case "$cmd" in
+  prepare|publish|finish)
+    [[ $# -eq 2 ]] || die "usage: $0 $cmd <X.Y.Z> [--dry-run]"
+    [[ "$version" =~ $RELEASE_RE ]] || die "invalid release version '$version' (expected X.Y.Z)"
+    need gh; need git
+    gh auth status >/dev/null 2>&1 || die "gh is not authenticated (gh auth login)"
+    "cmd_$cmd" "$version"
+    ;;
+  -h|--help|"")
+    sed -n '3,/^set -euo/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
+    [[ -n "$cmd" ]] || exit 1
+    ;;
+  *)
+    die "unknown command '$cmd' (prepare|publish|finish)"
+    ;;
+esac

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Sets or verifies the DepClean version in every file that carries it.
+#
+#   scripts/set-version.sh <version>          set <version> everywhere (X.Y.Z or X.Y.Z-SNAPSHOT)
+#   scripts/set-version.sh --check            fail if any location disagrees with the root pom.xml
+#   scripts/set-version.sh --readme-only <v>  update only README.md (used by the Deploy workflow)
+#
+# The root pom.xml is the single source of truth. The Maven modules are handled by
+# versions:set; everything else (Gradle plugin, test fixtures, READMEs) is a literal
+# string that this script keeps in sync. Every substitution is anchored on a DepClean
+# coordinate so unrelated versions (e.g. jcabi-manifests 2.2.0) are never touched.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+VERSION_RE='^[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?$'
+
+die() { echo "error: $*" >&2; exit 1; }
+
+pom_version() {
+  ./mvnw -ntp -q help:evaluate -Dexpression=project.version -DforceStdout
+}
+
+# Files where <version> is on the line right after <artifactId>depclean-maven-plugin</artifactId>
+MAVEN_XML_FILES=(
+  README.md
+  depclean-maven-plugin/src/test/resources/DepCleanMojoResources/pom-debloated.xml
+  depclean-core/src/test/resources/basic_spring_maven_project/pom.xml
+)
+
+GRADLE_BUILD=depclean-gradle-plugin/build.gradle
+GRADLE_README=depclean-gradle-plugin/README.md
+GRADLE_FIXTURES=(depclean-gradle-plugin/src/test/resources-fts/*/build.gradle)
+
+# apply <file> <anchor-regex> <sed-expression>
+# Applies the substitution and fails if the anchor does not occur in the file,
+# so a moved or renamed snippet is detected instead of silently skipped.
+apply() {
+  local file=$1 anchor=$2 expr=$3
+  [[ -f "$file" ]] || die "missing file: $file"
+  grep -Eq -- "$anchor" "$file" || die "anchor '$anchor' not found in $file"
+  sed -i -E -- "$expr" "$file"
+}
+
+set_readme() {
+  local v=$1
+  apply README.md '<artifactId>depclean-maven-plugin</artifactId>' \
+    "/<artifactId>depclean-maven-plugin<\/artifactId>/{n;s|<version>[^<]*</version>|<version>$v</version>|}"
+}
+
+set_literals() {
+  local v=$1 f
+  for f in "${MAVEN_XML_FILES[@]}"; do
+    apply "$f" '<artifactId>depclean-maven-plugin</artifactId>' \
+      "/<artifactId>depclean-maven-plugin<\/artifactId>/{n;s|<version>[^<]*</version>|<version>$v</version>|}"
+  done
+  apply "$GRADLE_BUILD" "^version = '" "s|^version = '[^']*'|version = '$v'|"
+  apply "$GRADLE_BUILD" "depcleanVersion = '" "s|(depcleanVersion = ')[^']*'|\1$v'|"
+  apply "$GRADLE_README" "depclean-gradle-plugin' version '" "s|(depclean-gradle-plugin' version ')[^']*'|\1$v'|"
+  for f in "${GRADLE_FIXTURES[@]}"; do
+    apply "$f" 'depclean-gradle-plugin:' "s|(depclean-gradle-plugin:)[^']*'|\1$v'|"
+  done
+}
+
+set_version() {
+  local v=$1
+  ./mvnw -ntp -q versions:set -DnewVersion="$v" -DgenerateBackupPoms=false -DprocessAllModules=true
+  set_literals "$v"
+  echo "version set to $v"
+}
+
+# Re-applies the literal substitutions with the pom version on a scratch copy of the
+# tree and diffs; any difference means a location has drifted from the pom.
+check_version() {
+  local v tmp rc=0
+  v=$(pom_version)
+  [[ "$v" =~ $VERSION_RE ]] || die "unexpected pom version '$v'"
+  tmp=$(mktemp -d)
+  # shellcheck disable=SC2064  # expand now: $tmp is local and gone when the trap fires
+  trap "rm -rf '$tmp'" EXIT
+  local files=("${MAVEN_XML_FILES[@]}" "$GRADLE_BUILD" "$GRADLE_README" "${GRADLE_FIXTURES[@]}")
+  local f
+  for f in "${files[@]}"; do
+    mkdir -p "$tmp/$(dirname "$f")"
+    cp -- "$f" "$tmp/$f"
+  done
+  (cd "$tmp" && set_literals "$v")
+  for f in "${files[@]}"; do
+    if ! diff -q -- "$f" "$tmp/$f" >/dev/null; then
+      echo "MISMATCH $f"
+      diff -u -- "$f" "$tmp/$f" | grep -E '^[-+][^-+]' || true
+      rc=1
+    fi
+  done
+  if [[ $rc -eq 0 ]]; then
+    echo "all version references match pom.xml ($v)"
+  else
+    echo "run: scripts/set-version.sh $v" >&2
+  fi
+  return $rc
+}
+
+case "${1:-}" in
+  --check)
+    [[ $# -eq 1 ]] || die "--check takes no arguments"
+    check_version
+    ;;
+  --readme-only)
+    [[ $# -eq 2 && "$2" =~ $VERSION_RE ]] || die "usage: $0 --readme-only X.Y.Z"
+    set_readme "$2"
+    ;;
+  -h|--help|"")
+    sed -n '3,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+    [[ -n "${1:-}" ]] || exit 1
+    ;;
+  *)
+    [[ $# -eq 1 && "$1" =~ $VERSION_RE ]] || die "invalid version '$1' (expected X.Y.Z or X.Y.Z-SNAPSHOT)"
+    set_version "$1"
+    ;;
+esac


### PR DESCRIPTION
## Why

After the 2.2.0 release, `master` was red for two days: the Maven POMs were bumped to `2.2.0`, but the Gradle plugin still resolved `depclean-core`/`depclean-maven-plugin` at `2.2.0-SNAPSHOT` (`Could not find se.kth.castor:depclean-core:2.2.0-SNAPSHOT`). The version is carried as a literal in 12 places outside the POMs, and nothing checked that they agree.

## What

- **`scripts/set-version.sh <version>`** — sets the version everywhere from one command: `versions:set -DprocessAllModules` for the POMs, anchored substitutions for the Gradle plugin (`version`, `depcleanVersion`), the 7 Gradle functional-test fixtures, both READMEs and the two Maven test fixtures with a literal plugin version. Every substitution is anchored on a DepClean coordinate, so unrelated versions (e.g. `jcabi-manifests:2.2.0`) are never touched, and it fails if an anchor disappears.
- **`scripts/set-version.sh --check`** — fails with a per-line report when any location drifts from `pom.xml`. **New CI job `version-consistency` runs it** on every push/PR, so this class of breakage is caught before merge.
- **`scripts/release.sh prepare | publish | finish <X.Y.Z>`** — wraps the documented release steps around the existing Deploy workflow using `gh`: bump + sanity build + release PR; dispatch Deploy on `master` and wait for the approval/run; wait for Central, publish the draft GitHub release and open the next-`-SNAPSHOT` PR. Each step checks its preconditions (clean, up-to-date `master`, tag/release not existing, POM version) and supports `--dry-run`.
- `deploy.yml`'s README step calls `set-version.sh --readme-only` instead of an unanchored `sed` (safety net; the release PR already updates the README).
- `CONTRIBUTING.md` release section rewritten around the scripts.
- Fixes the last drifted reference: `depclean-core/src/test/resources/basic_spring_maven_project/pom.xml` was still `2.2.0-SNAPSHOT`.

## Verification

- `scripts/set-version.sh --check` passes on this branch; on pre-#530 `master` it reported all 10 drifted files.
- Round trip `2.2.0 -> 9.9.9-SNAPSHOT -> 2.2.0` leaves a clean tree; the `jcabi` `2.2.0` in `json_should_be_correct/pom.xml` is untouched.
- `./mvnw -pl depclean-core -am test`: 68 tests, 0 failures. Gradle `./gradlew clean publishToMavenLocal build`: 18 tests, 0 failures.
- `release.sh prepare/publish/finish --dry-run` exercised against current `master`; `shellcheck -x` clean.

## Notes

- `deploy.yml` still declares `previousVersion` (required) but no longer uses it — kept so the documented manual process and `release.sh publish` keep working; can be dropped in a follow-up.
- `versions:set` also refreshes `project.build.outputTimestamp` in the root POM, which is the intended behaviour for a release bump.
