### PR TITLE
chore: bump version to 2.2.1-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Configure the `pom.xml` file of your Maven project to use DepClean as part of th
 <plugin>
   <groupId>se.kth.castor</groupId>
   <artifactId>depclean-maven-plugin</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <executions>
     <execution>
       <goals>
@@ -115,7 +115,7 @@ For example, if you want to fail the build in the presence of unused direct depe
 <plugin>
   <groupId>se.kth.castor</groupId>
   <artifactId>depclean-maven-plugin</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <executions>
     <execution>
       <goals>

--- a/depclean-core/pom.xml
+++ b/depclean-core/pom.xml
@@ -8,12 +8,12 @@
   <parent>
     <groupId>se.kth.castor</groupId>
     <artifactId>depclean-parent-pom</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <!-- Coordinates -->
   <artifactId>depclean-core</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
 
   <packaging>jar</packaging>
 

--- a/depclean-core/src/test/resources/basic_spring_maven_project/pom.xml
+++ b/depclean-core/src/test/resources/basic_spring_maven_project/pom.xml
@@ -45,7 +45,7 @@
         <!-- see https://github.com/castor-software/depclean -->
         <groupId>se.kth.castor</groupId>
         <artifactId>depclean-maven-plugin</artifactId>
-        <version>2.2.0</version>
+        <version>2.2.1-SNAPSHOT</version>
         <executions>
           <execution>
             <goals>

--- a/depclean-gradle-plugin/README.md
+++ b/depclean-gradle-plugin/README.md
@@ -29,7 +29,7 @@ Then add the plugin to your `build.gradle` file:
 
 ```groovy
 plugins {
-    id 'se.kth.castor.depclean-gradle-plugin' version '2.2.0'
+    id 'se.kth.castor.depclean-gradle-plugin' version '2.2.1-SNAPSHOT'
 }
 ```
 Then, you can run the `debloat` task to analyze your project and remove unused dependencies:

--- a/depclean-gradle-plugin/build.gradle
+++ b/depclean-gradle-plugin/build.gradle
@@ -27,7 +27,7 @@ tasks.withType(GroovyCompile).configureEach {
 }
 
 group = 'se.kth.castor'
-version = '2.2.0'
+version = '2.2.1-SNAPSHOT'
 
 repositories {
   mavenLocal()
@@ -35,7 +35,7 @@ repositories {
 }
 
 ext {
-    depcleanVersion = '2.2.0'
+    depcleanVersion = '2.2.1-SNAPSHOT'
     errorProneCoreVersion = '2.50.0'
     jspecifyVersion = '1.0.1'
     nullawayVersion = '0.14.1'

--- a/depclean-gradle-plugin/src/test/resources-fts/all_dependencies_unused/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/all_dependencies_unused/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.1-SNAPSHOT'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/all_dependencies_used/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/all_dependencies_used/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.1-SNAPSHOT'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/debloated_dependencies.gradle_is_correct/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/debloated_dependencies.gradle_is_correct/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.1-SNAPSHOT'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/empty_project/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/empty_project/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.1-SNAPSHOT'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/json_should_be_correct/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/json_should_be_correct/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.1-SNAPSHOT'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/multi_project/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/multi_project/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.1-SNAPSHOT'
     }
 }
 

--- a/depclean-gradle-plugin/src/test/resources-fts/xml_config_classes_used/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/xml_config_classes_used/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.0'
+        classpath 'se.kth.castor:depclean-gradle-plugin:2.2.1-SNAPSHOT'
     }
 }
 

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -8,12 +8,12 @@
   <parent>
     <groupId>se.kth.castor</groupId>
     <artifactId>depclean-parent-pom</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <!-- Coordinates -->
   <artifactId>depclean-maven-plugin</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
 
   <packaging>maven-plugin</packaging>
 

--- a/depclean-maven-plugin/src/test/resources/DepCleanMojoResources/pom-debloated.xml
+++ b/depclean-maven-plugin/src/test/resources/DepCleanMojoResources/pom-debloated.xml
@@ -80,7 +80,7 @@
       <plugin>
         <groupId>se.kth.castor</groupId>
         <artifactId>depclean-maven-plugin</artifactId>
-        <version>2.2.0</version>
+        <version>2.2.1-SNAPSHOT</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <!-- Coordinates -->
   <groupId>se.kth.castor</groupId>
   <artifactId>depclean-parent-pom</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!-- Name of the parent module -->
@@ -59,7 +59,7 @@
     <java.version>8</java.version>
     <java.test.version>17</java.test.version>
     <linkXRef>false</linkXRef>
-    <project.build.outputTimestamp>2026-09-04T13:25:46Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-09-06T07:50:48Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>


### PR DESCRIPTION
Post-release housekeeping after 2.2.0: all version references (POMs, Gradle plugin, test fixtures, READMEs) move to `2.2.1-SNAPSHOT` via `scripts/set-version.sh 2.2.1-SNAPSHOT`. `scripts/set-version.sh --check` passes.

This is what `scripts/release.sh finish` will do automatically for future releases.