### PR TITLE
ci: deploy GitHub Pages from README via Actions; drop old-org URLs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,66 @@
+name: Pages
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - README.md
+      - .img/**
+      - docs/**
+      - .github/workflows/pages.yml
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: pages
+  cancel-in-progress: false
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # README.md is the single source of the site content; docs/ only holds the Jekyll config.
+      - name: Assemble site sources
+        env:
+          BLOB_URL: ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}
+        run: |
+          mkdir -p _pages
+          cp docs/_config.yml _pages/
+          cp -r .img _pages/
+          { printf -- '---\nlayout: default\n---\n\n'; cat README.md; } > _pages/index.md
+          # Relative links to repository files (LICENSE.md, CONTRIBUTING.md, ...) only resolve on GitHub
+          perl -pi -e 's{\]\((?!https?://|#|\.img/|mailto:)([^)\s]+)\)}{]($ENV{BLOB_URL}/$1)}g' _pages/index.md
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
+        with:
+          source: ./_pages
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/depclean-core/src/test/resources/basic_spring_maven_project/pom.xml
+++ b/depclean-core/src/test/resources/basic_spring_maven_project/pom.xml
@@ -42,7 +42,7 @@
       </plugin>
 
       <plugin>
-        <!-- see https://github.com/castor-software/depclean -->
+        <!-- see https://github.com/ASSERT-KTH/depclean -->
         <groupId>se.kth.castor</groupId>
         <artifactId>depclean-maven-plugin</artifactId>
         <version>2.2.0</version>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,9 @@
+# Jekyll configuration for the GitHub Pages site (https://assert-kth.github.io/depclean/).
+# The page content is README.md, staged as index.md by .github/workflows/pages.yml.
+title: DepClean
+description: Automatically detects and removes unused dependencies in Maven and Gradle projects
+theme: jekyll-theme-cayman
+show_downloads: false
+# Jekyll skips dot-directories by default; the README images live in .img/
+include:
+  - .img

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
     </plugins>
   </build>
 
-  <url>https://github.com/castor-software/depclean</url>
+  <url>https://github.com/ASSERT-KTH/depclean</url>
 
   <!-- License statement -->
   <licenses>
@@ -314,15 +314,15 @@
 
   <!-- SCM -->
   <scm>
-    <connection>scm:git:git:github.com/castor-software/depclean.git</connection>
-    <developerConnection>scm:git:git@github.com:castor-software/depclean.git</developerConnection>
-    <url>https://github.com/castor-software/depclean/</url>
+    <connection>scm:git:git:github.com/ASSERT-KTH/depclean.git</connection>
+    <developerConnection>scm:git:git@github.com:ASSERT-KTH/depclean.git</developerConnection>
+    <url>https://github.com/ASSERT-KTH/depclean/</url>
   </scm>
 
   <!-- Issues are managed on GitHub -->
   <issueManagement>
     <system>GitHub Issues</system>
-    <url>https://github.com/castor-software/depclean/issues</url>
+    <url>https://github.com/ASSERT-KTH/depclean/issues</url>
   </issueManagement>
 
   <!-- Releases are published to Maven Central through the Central Publisher Portal, which the


### PR DESCRIPTION
## Why

The GitHub Pages site (https://assert-kth.github.io/depclean/) is still served from the `gh-pages` branch, last touched in **March 2020**. It documents DepClean 1.0.0, shows Travis-CI badges, links everywhere to the old `castor-software` org (repo, license, tarballs, Sonar), hot-links the logo from a personal website, and even contains leaked `target/nexus-staging/**` release artifacts with `.asc` signatures. The repo is already set to `build_type: workflow` in the Pages settings, but no workflow exists.

## What

- **`.github/workflows/pages.yml`** — the standard Actions deployment (`configure-pages` → `jekyll-build-pages` → `upload-pages-artifact` → `deploy-pages`, all SHA-pinned). Runs on pushes to `master` touching `README.md`, `.img/**`, `docs/**` or the workflow, plus `workflow_dispatch`.
  - **README.md is the single source of the site content**: it is staged as `index.md` with front matter, together with `.img/`. No duplicated docs to keep in sync.
  - Relative repository links (`LICENSE.md`, `CONTRIBUTING.md`, `depclean-gradle-plugin/README.md`, …) only resolve on GitHub, so they are rewritten to `blob/master` URLs at build time; anchors, `.img/` and external URLs are left alone.
- **`docs/_config.yml`** — Jekyll config (Cayman theme, title/description). `.img/` is a dot-directory, which Jekyll skips by default; it is explicitly `include`d so the logo, demo GIF and WASP logo actually ship — that's why images were missing before.
- **Old-org URLs**: `pom.xml` `<url>`, `<scm>` and `<issueManagement>` and a fixture comment still pointed at `github.com/castor-software/depclean`; moved to `ASSERT-KTH`. `git grep castor-software` is now empty.

## Verification

Built locally with the exact `ghcr.io/actions/jekyll-build-pages:v1.0.13` image and served under `/depclean/`: all three images load (`naturalWidth > 0`), badges render, TOC anchors work, and every repository link resolves to `https://github.com/ASSERT-KTH/depclean/...`.

## Follow-up (after merge, once the first deployment is live)

1. Delete the `gh-pages` branch (no longer the source; keeping it only preserves the leaked artifacts).
2. Deactivate/delete the 15 legacy `github-pages` deployments from 2019–2020.
3. Set the repository homepage to `https://assert-kth.github.io/depclean/`.

The `github-pages` environment already allows deployments from `master`.
