### PR TITLE
ci(pages): ship README images from img/, not .img/

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,10 +32,12 @@ jobs:
         run: |
           mkdir -p _pages
           cp docs/_config.yml _pages/
-          cp -r .img _pages/
+          # Pages does not serve dot-directories, so .img/ ships as img/
+          cp -r .img _pages/img
           { printf -- '---\nlayout: default\n---\n\n'; cat README.md; } > _pages/index.md
+          sed -i 's#\.img/#img/#g' _pages/index.md
           # Relative links to repository files (LICENSE.md, CONTRIBUTING.md, ...) only resolve on GitHub
-          perl -pi -e 's{\]\((?!https?://|#|\.img/|mailto:)([^)\s]+)\)}{]($ENV{BLOB_URL}/$1)}g' _pages/index.md
+          perl -pi -e 's{\]\((?!https?://|#|img/|mailto:)([^)\s]+)\)}{]($ENV{BLOB_URL}/$1)}g' _pages/index.md
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,3 @@ title: DepClean
 description: Automatically detects and removes unused dependencies in Maven and Gradle projects
 theme: jekyll-theme-cayman
 show_downloads: false
-# Jekyll skips dot-directories by default; the README images live in .img/
-include:
-  - .img


### PR DESCRIPTION
Follow-up to #534: the live site had all three images as 404.

`actions/upload-pages-artifact` uploads with `include-hidden-files: false`, so the `.img/` directory was silently dropped from the artifact (the local Jekyll build had it, which is why it looked fine). Stage the images as `img/` and rewrite the README references at build time; the `include: [.img]` Jekyll setting is no longer needed.

Verified with the action's Jekyll image: `_site` contains `img/{logo.svg,demo.gif,wasp.svg}`, no hidden paths, and all `<img>` tags point at `img/`.