### PR TITLE
docs: align READMEs, SECURITY, CITATION and parameter javadoc with the code

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,23 @@
 cff-version: 1.2.0
+message: "If you use DepClean in academic work, please cite the paper below (preferred-citation)."
+type: software
+title: "DepClean"
+abstract: "DepClean automatically detects and removes unused dependencies in Maven (and Gradle) projects."
+repository-code: "https://github.com/ASSERT-KTH/depclean"
+license: MIT
+authors:
+  - family-names: Soto-Valero
+    given-names: César
+    orcid: "https://orcid.org/0000-0003-0541-6411"
+  - family-names: Harrand
+    given-names: Nicolas
+    orcid: "https://orcid.org/0000-0002-2491-2771"
+  - family-names: Monperrus
+    given-names: Martin
+    orcid: "https://orcid.org/0000-0003-3505-3383"
+  - family-names: Baudry
+    given-names: Benoit
+    orcid: "https://orcid.org/0000-0002-4015-4640"
 preferred-citation:
   type: article
   title: "A Comprehensive Study of Bloated Dependencies in the Maven Ecosystem"
@@ -8,14 +27,14 @@ preferred-citation:
   volume: 26
   issue: 3
   start: 1
-  end: 44  
+  end: 44
   authors:
     - family-names: Soto-Valero
       given-names: César
       orcid: "https://orcid.org/0000-0003-0541-6411"
     - family-names: Harrand
       given-names: Nicolas
-      orcid: "https://orcid.org/ 0000-0002-2491-2771"
+      orcid: "https://orcid.org/0000-0002-2491-2771"
     - family-names: Monperrus
       given-names: Martin
       orcid: "https://orcid.org/0000-0003-3505-3383"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ cd depclean-gradle-plugin
 ## Code style
 
 - Java code follows a [Google Java Style](https://google.github.io/styleguide/javaguide.html)-based configuration enforced by Checkstyle ([checkstyle.xml](checkstyle.xml)). Checkstyle runs as part of the Maven build.
-- The Gradle plugin module uses [Spotless](https://github.com/diffplug/spotless); run `./gradlew spotlessApply` to format.
+- Formatting is done with [Spotless](https://github.com/diffplug/spotless) (google-java-format): run `./mvnw spotless:apply` for the Maven modules and `./gradlew spotlessApply` in `depclean-gradle-plugin`.
 
 ## Tests
 
@@ -55,7 +55,7 @@ Please follow the checklist in the [pull request template](.github/PULL_REQUEST_
 
 Releases are published to Maven Central through the [Central Publisher Portal](https://central.sonatype.com) (see the [Sonatype Maven guide](https://central.sonatype.org/publish/publish-portal-maven/)) by the [Deploy workflow](.github/workflows/deploy.yml).
 
-The version is carried not only by the Maven POMs but also by the Gradle plugin, its test fixtures and the READMEs. `scripts/set-version.sh <version>` updates all of them at once, and CI fails if any of them drifts from `pom.xml` (`scripts/set-version.sh --check`). Never bump versions by hand.
+The version is carried not only by the Maven POMs but also by the Gradle plugin, its test fixtures and the READMEs. `scripts/set-version.sh <version>` updates all of them at once, and CI fails if any of them drifts from `pom.xml` (`scripts/set-version.sh --check`). Never bump versions by hand. The one exception is the root `README.md`: it documents the plugin as consumed from Maven Central, so it always shows the latest *release* and is not touched by `-SNAPSHOT` bumps (the Gradle plugin README does follow the snapshot, because that plugin is only available from a local build).
 
 `scripts/release.sh` drives the release from a clean, up-to-date `master` checkout (needs an authenticated `gh`):
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Configure the `pom.xml` file of your Maven project to use DepClean as part of th
 <plugin>
   <groupId>se.kth.castor</groupId>
   <artifactId>depclean-maven-plugin</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.0</version>
   <executions>
     <execution>
       <goals>
@@ -101,10 +101,11 @@ The Maven plugin can be configured with the following additional parameters.
 | `<ignoreTests>`            |   `boolean`   | If this is true, DepClean will not analyze the test classes in the project, and, therefore, the dependencies that are only used for testing will be considered unused. This parameter is useful to detect dependencies that have `compile` scope but are only used for testing. **Default value is:** `false`.                                                                                                              |
 | `<createPomDebloated>`     |   `boolean`   | If this is true, DepClean creates a debloated version of the pom without unused dependencies called `pom-debloated.xml`, in the root of the project. **Default value is:** `false`.                                                                                                                                                                                                                                         |
 | `<createResultJson>`       |   `boolean`   | If this is true, DepClean creates a JSON file of the dependency tree along with metadata of each dependency. The file is called `depclean-results.json`, and is located in the `target` directory of the project. **Default value is:** `false`.                                                                                                                                                                            |
-| `<createCallGraphCsv>`     |   `boolean`   | If this is true, DepClean creates a CSV file with the static call graph of the API members used in the project. The file is called `depclean-callgraph.csv`, and is located in the `target` directory of the project. **Default value is:** `false`.                                                                                                                                                                        |
+| `<createCallGraphCsv>`     |   `boolean`   | If this is true, DepClean creates a CSV file with the static call graph of the API members used in the project. The file is called `depclean-callgraph.csv`, and is located in the `target` directory of the project. It is only written together with the JSON report, so `createResultJson` must be true as well. **Default value is:** `false`.                                                                                       |
 | `<failIfUnusedDirect>`     |   `boolean`   | If this is true, and DepClean reported any unused direct dependency in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                                                                                              |
 | `<failIfUnusedTransitive>` |   `boolean`   | If this is true, and DepClean reported any unused transitive dependency in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                                                                                          |
-| `<failIfUnusedInherited>`  |   `boolean`   | If this is true, and DepClean reported any unused inherited dependency in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                                                                                           |
+| `<failIfUnusedInheritedDirect>` | `boolean` | If this is true, and DepClean reported any unused inherited direct dependency (declared in a parent POM) in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                                                    |
+| `<failIfUnusedInheritedTransitive>` | `boolean` | If this is true, and DepClean reported any unused inherited transitive dependency (pulled in through a parent POM's dependencies) in the dependency tree, the build fails immediately after running DepClean. **Default value is:** `false`.                                                                                                                                                                       |
 | `<skipDepClean>`           |   `boolean`   | Skip plugin execution completely. **Default value is:** `false`.                                                                                                                                                                                                                                                                                                                                                            |
 
 You can integrate DepClean in your CI/CD pipeline.
@@ -115,7 +116,7 @@ For example, if you want to fail the build in the presence of unused direct depe
 <plugin>
   <groupId>se.kth.castor</groupId>
   <artifactId>depclean-maven-plugin</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.0</version>
   <executions>
     <execution>
       <goals>
@@ -138,7 +139,7 @@ mvn se.kth.castor:depclean-maven-plugin:2.2.0:depclean -DfailIfUnusedDirect=true
 
 ## How does DepClean work?
 
-DepClean runs before executing the `package` phase of the Maven build lifecycle. It statically collects all the types
+By default, DepClean binds to the `package` phase of the Maven build lifecycle. It statically collects all the types
 referenced in the project under analysis as well as in its declared dependencies. Then, it compares the types that the
 project actually uses in the bytecode with respect to the class members belonging to its dependencies.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the latest release of DepClean is supported with security updates.
 
 | Version | Supported |
 | ------- | --------- |
-| 2.1.x   | ✅        |
-| < 2.1   | ❌        |
+| 2.2.x   | ✅        |
+| < 2.2   | ❌        |
 
 ## Reporting a Vulnerability
 
@@ -21,4 +21,4 @@ Instead, report it privately via [GitHub private vulnerability reporting](https:
 
 You will receive a response as soon as possible. Once the issue is confirmed and a fix is available, a security advisory will be published and the fix released.
 
-Note that DepClean is a build-time analysis tool: it does not run in production environments, and it does not modify your source code or original `pom.xml`. Vulnerabilities in DepClean's own dependencies are tracked continuously via Dependabot and SonarCloud.
+Note that DepClean is a build-time analysis tool: it does not run in production environments, and it does not modify your source code or original `pom.xml`. Vulnerabilities in DepClean's own dependencies are tracked continuously via Renovate (including GitHub and OSV vulnerability alerts) and SonarCloud.

--- a/depclean-gradle-plugin/README.md
+++ b/depclean-gradle-plugin/README.md
@@ -1,7 +1,7 @@
 ## DepClean Gradle Plugin
 
 The DepClean Gradle plugin is designed to automatically detect and remove unused dependencies in Gradle-based Java projects.
-It uses `depclean-core` for the heavy bytecode analysis tasks, and provides a Gradle task to remove unused dependencies from the project's `build.gradle` file.
+It uses `depclean-core` for the heavy bytecode analysis tasks, and provides a Gradle task that reports the unused dependencies of the project and can write a debloated `dependencies { }` block to replace the one in your `build.gradle` file. It never modifies your `build.gradle` itself.
 As with the DepClean Maven plugin, this is a powerful tool to keep your project lean, avoid unnecessary compilation and potential conflicts or security vulnerabilities due to bloated dependencies.
 
 ### Prototype Stage
@@ -40,19 +40,29 @@ Then, you can run the `debloat` task to analyze your project and remove unused d
 
 ### Optional Parameters
 
-The class [DepCleanGradlePluginExtension.java](https://github.com/ASSERT-KTH/depclean/blob/master/depclean-gradle-plugin/src/main/java/se/kth/depclean/DepCleanGradlePluginExtension.java) contains the following parameters currently accepted by DepClean Gradle plugin:
- 
-- `project`: This refers to the Gradle project that will be analyzed by the plugin.
+The plugin is configured through the `depclean { }` extension in `build.gradle`, for example:
+
+```groovy
+depclean {
+    createBuildDebloated = true
+    createResultJson = true
+    ignoreConfiguration = ['testCompile']
+}
+```
+
+The class [DepCleanGradlePluginExtension.java](https://github.com/ASSERT-KTH/depclean/blob/master/depclean-gradle-plugin/src/main/java/se/kth/depclean/DepCleanGradlePluginExtension.java) contains the following parameters currently accepted by DepClean Gradle plugin (all `false`/unset by default):
+
+- `project`: The Gradle project to analyze. It defaults to the project the plugin is applied to and normally does not need to be set.
 - `skipDepClean`: If this is set to true, the execution of the DepClean plugin will be completely skipped.
 - `ignoreTest`: When this parameter is set to true, DepClean will not analyze the test sources in the project. Dependencies only used for testing will be considered unused.
 - `failIfUnusedDirect`: If set to true, and if DepClean identifies any unused direct dependency, the project's build will fail immediately.
 - `failIfUnusedTransitive`: Similar to `failIfUnusedDirect`, but in this case, the build will fail if any unused transitive dependencies are identified.
 - `failIfUnusedInherited`: If true and DepClean finds any unused inherited dependency, the build fails immediately.
-- `createBuildDebloated`: If set to `true`, it will generate a debloated version of the `build.gradle` file without the unused dependencies, and name it `debloated-build.gradle`.
-- `createResultJson`: When this is `true`, DepClean generates a JSON file with the results of the analysis, named `debloat-result.json`.
-- `createClassUsageCsv`: If this is set to `true`, it generates a CSV file with the result of the analysis, including the columns: `OriginClass`, `TargetClass`, and `Dependency`. The file is named `class-usage.csv.
-- `ignoreConfiguration`: This parameter allows you to ignore dependencies with specific configurations from the DepClean analysis.
-- `ignoreDependency`: This parameter accepts a set of dependencies (identified by their coordinates) that should be ignored by the plugin during the analysis and considered as used dependencies.
+- `createBuildDebloated`: If set to `true`, it will generate a `debloated-dependencies.gradle` file in the project directory containing a `dependencies { }` block without the unused dependencies (used transitive dependencies are added as direct ones, unused transitive dependencies are excluded).
+- `createResultJson`: When this is `true`, DepClean generates a JSON file with the results of the analysis, named `depclean-results.json`, in the `build` directory.
+- `createClassUsageCsv`: If this is set to `true`, it generates a CSV file with the result of the analysis, including the columns: `OriginClass`, `TargetClass`, and `Dependency`. The file is named `class-usage.csv` and is located in the `build` directory. It is only written together with the JSON report, so `createResultJson` must be `true` as well.
+- `ignoreConfiguration`: A set of configuration names (as printed in the analysis results, e.g. `compile`, `testCompile`) whose dependencies are excluded from the DepClean results.
+- `ignoreDependency`: A set of dependencies that should be ignored by the plugin during the analysis and considered as used dependencies. Each entry must match a coordinate exactly as printed in the analysis results, i.e. `group:name:version:configuration`.
 
 ### Looking for Contributors
 

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/DepCleanGradlePluginExtension.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/DepCleanGradlePluginExtension.java
@@ -40,31 +40,36 @@ public class DepCleanGradlePluginExtension {
   public boolean failIfUnusedInherited = false;
 
   /**
-   * If this is true, DepClean creates a debloated version of the build.gradle without unused
-   * dependencies, called "debloated-build.gradle", in root of the project.
+   * If this is true, DepClean writes a debloated {@code dependencies} block without unused
+   * dependencies to "debloated-dependencies.gradle", in root of the project.
    */
   public boolean createBuildDebloated = false;
 
   /**
    * If this is true, DepClean creates a JSON file with the result of the analysis. The file is
-   * called "debloat-result.json" and it is located in /build.
+   * called "depclean-results.json" and it is located in /build.
    */
   public boolean createResultJson = false;
 
   /**
    * If this is true, DepClean creates a CSV file with the result of the analysis with the columns:
    * OriginClass,TargetClass,Dependency. The file is called "class-usage.csv" and it is located in
-   * /target.
+   * /build. It is only written together with the JSON result, i.e. when {@code createResultJson} is
+   * also true.
    */
   public boolean createClassUsageCsv;
 
-  /** Ignore dependencies with specific configurations from the DepClean analysis. */
+  /**
+   * Ignore dependencies with specific configurations (as printed in the analysis results, e.g.
+   * "compile", "testCompile") from the DepClean analysis.
+   */
   @Nullable public Set<String> ignoreConfiguration;
 
   /**
    * Add a list of dependencies, identified by their coordinates, to be ignored by DepClean during
    * the analysis and considered as used dependencies. Useful to override incomplete result caused
-   * by bytecode-level analysis Dependency format is <code>groupId:artifactId:version</code>.
+   * by bytecode-level analysis. Each entry must match a coordinate exactly as printed in the
+   * analysis results, i.e. <code>group:name:version:configuration</code>.
    */
   @Nullable public Set<String> ignoreDependency;
 

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
@@ -64,14 +64,14 @@ public class DepCleanMojo extends AbstractMojo {
 
   /**
    * If this is true, DepClean creates a debloated version of the pom without unused dependencies,
-   * called "debloated-pom.xml", in root of the project.
+   * called "pom-debloated.xml", in root of the project.
    */
   @Parameter(property = "createPomDebloated", defaultValue = "false")
   private boolean createPomDebloated;
 
   /**
    * If this is true, DepClean creates a JSON file with the result of the analysis. The file is
-   * called "debloat-result.json" and it is located in /target.
+   * called "depclean-results.json" and it is located in /target.
    */
   @Parameter(property = "createResultJson", defaultValue = "false")
   private boolean createResultJson;
@@ -79,15 +79,17 @@ public class DepCleanMojo extends AbstractMojo {
   /**
    * If this is true, DepClean creates a CSV file with the result of the analysis with the columns:
    * OriginClass,TargetClass,OriginDependency,TargetDependency. The file is called
-   * "depclean-callgraph.csv" and it is located in /target.
+   * "depclean-callgraph.csv" and it is located in /target. It is only written together with the
+   * JSON result, i.e. when {@code createResultJson} is also true.
    */
   @Parameter(property = "createCallGraphCsv", defaultValue = "false")
   private boolean createCallGraphCsv;
 
   /**
-   * Add a list of dependencies, identified by their coordinates, to be ignored by DepClean during
-   * the analysis and considered as used dependencies. Useful to override incomplete result caused
-   * by bytecode-level analysis Dependency format is <code>groupId:artifactId:version</code>.
+   * Add a list of regular expressions matching dependencies to be ignored by DepClean during the
+   * analysis and considered as used dependencies. Useful to override incomplete result caused by
+   * bytecode-level analysis. Each pattern is matched (case-insensitively) against the whole <code>
+   * groupId:artifactId:version:scope</code> coordinate, e.g. <code>com.google.guava.*</code>.
    */
   @Parameter(property = "ignoreDependencies")
   @SuppressWarnings("NullAway") // Injected by Maven
@@ -122,15 +124,17 @@ public class DepCleanMojo extends AbstractMojo {
   private boolean failIfUnusedTransitive;
 
   /**
-   * If this is true, and DepClean reported any unused inherited dependency in the dependency tree,
-   * then the project's build fails immediately after running DepClean.
+   * If this is true, and DepClean reported any unused inherited direct dependency (declared in a
+   * parent POM) in the dependency tree, then the project's build fails immediately after running
+   * DepClean.
    */
   @Parameter(property = "failIfUnusedInheritedDirect", defaultValue = "false")
   private boolean failIfUnusedInheritedDirect;
 
   /**
-   * If this is true, and DepClean reported any unused inherited dependency in the dependency tree,
-   * then the project's build fails immediately after running DepClean.
+   * If this is true, and DepClean reported any unused inherited transitive dependency (pulled in
+   * through a parent POM's dependencies) in the dependency tree, then the project's build fails
+   * immediately after running DepClean.
    */
   @Parameter(property = "failIfUnusedInheritedTransitive", defaultValue = "false")
   private boolean failIfUnusedInheritedTransitive;

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -10,11 +10,16 @@
 # versions:set; everything else (Gradle plugin, test fixtures, READMEs) is a literal
 # string that this script keeps in sync. Every substitution is anchored on a DepClean
 # coordinate so unrelated versions (e.g. jcabi-manifests 2.2.0) are never touched.
+#
+# Exception: the root README.md documents the plugin as consumed from Maven Central, so
+# it carries the latest RELEASE and is left alone when the pom moves to a -SNAPSHOT;
+# --check then only requires it to be a single, consistent release version.
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 VERSION_RE='^[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?$'
+RELEASE_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
 
 die() { echo "error: $*" >&2; exit 1; }
 
@@ -22,9 +27,10 @@ pom_version() {
   ./mvnw -ntp -q help:evaluate -Dexpression=project.version -DforceStdout
 }
 
+README=README.md
+
 # Files where <version> is on the line right after <artifactId>depclean-maven-plugin</artifactId>
 MAVEN_XML_FILES=(
-  README.md
   depclean-maven-plugin/src/test/resources/DepCleanMojoResources/pom-debloated.xml
   depclean-core/src/test/resources/basic_spring_maven_project/pom.xml
 )
@@ -43,10 +49,19 @@ apply() {
   sed -i -E -- "$expr" "$file"
 }
 
+# The README carries the version both in <plugin> snippets and in
+# `mvn se.kth.castor:depclean-maven-plugin:<version>:depclean` command lines.
 set_readme() {
   local v=$1
-  apply README.md '<artifactId>depclean-maven-plugin</artifactId>' \
+  apply "$README" '<artifactId>depclean-maven-plugin</artifactId>' \
     "/<artifactId>depclean-maven-plugin<\/artifactId>/{n;s|<version>[^<]*</version>|<version>$v</version>|}"
+  apply "$README" 'se\.kth\.castor:depclean-maven-plugin:[^:]+:depclean' \
+    "s|(se\.kth\.castor:depclean-maven-plugin:)[^:]+(:depclean)|\1$v\2|g"
+}
+
+# Version the README currently documents (first <plugin> snippet).
+readme_version() {
+  sed -n -E "/<artifactId>depclean-maven-plugin<\/artifactId>/{n;s|.*<version>([^<]*)</version>.*|\1|p;q}" "$README"
 }
 
 set_literals() {
@@ -55,6 +70,10 @@ set_literals() {
     apply "$f" '<artifactId>depclean-maven-plugin</artifactId>' \
       "/<artifactId>depclean-maven-plugin<\/artifactId>/{n;s|<version>[^<]*</version>|<version>$v</version>|}"
   done
+  # README documents the latest release only; a SNAPSHOT bump must not touch it.
+  if [[ "$v" =~ $RELEASE_RE ]]; then
+    set_readme "$v"
+  fi
   apply "$GRADLE_BUILD" "^version = '" "s|^version = '[^']*'|version = '$v'|"
   apply "$GRADLE_BUILD" "depcleanVersion = '" "s|(depcleanVersion = ')[^']*'|\1$v'|"
   apply "$GRADLE_README" "depclean-gradle-plugin' version '" "s|(depclean-gradle-plugin' version ')[^']*'|\1$v'|"
@@ -71,21 +90,29 @@ set_version() {
 }
 
 # Re-applies the literal substitutions with the pom version on a scratch copy of the
-# tree and diffs; any difference means a location has drifted from the pom.
+# tree and diffs; any difference means a location has drifted from the pom. The README
+# is normalised to the release it documents (the pom version when that is a release),
+# so the diff catches both drift from a release and inconsistent occurrences.
 check_version() {
-  local v tmp rc=0
+  local v rv tmp rc=0
   v=$(pom_version)
   [[ "$v" =~ $VERSION_RE ]] || die "unexpected pom version '$v'"
+  rv=$(readme_version)
+  [[ "$rv" =~ $RELEASE_RE ]] || { echo "MISMATCH $README: documents '$rv', expected a release version (X.Y.Z)"; rc=1; }
   tmp=$(mktemp -d)
   # shellcheck disable=SC2064  # expand now: $tmp is local and gone when the trap fires
   trap "rm -rf '$tmp'" EXIT
-  local files=("${MAVEN_XML_FILES[@]}" "$GRADLE_BUILD" "$GRADLE_README" "${GRADLE_FIXTURES[@]}")
+  local files=("${MAVEN_XML_FILES[@]}" "$README" "$GRADLE_BUILD" "$GRADLE_README" "${GRADLE_FIXTURES[@]}")
   local f
   for f in "${files[@]}"; do
     mkdir -p "$tmp/$(dirname "$f")"
     cp -- "$f" "$tmp/$f"
   done
-  (cd "$tmp" && set_literals "$v")
+  (
+    cd "$tmp"
+    set_literals "$v"
+    [[ "$v" =~ $RELEASE_RE ]] || set_readme "$rv"
+  )
   for f in "${files[@]}"; do
     if ! diff -q -- "$f" "$tmp/$f" >/dev/null; then
       echo "MISMATCH $f"
@@ -97,6 +124,7 @@ check_version() {
     echo "all version references match pom.xml ($v)"
   else
     echo "run: scripts/set-version.sh $v" >&2
+    [[ "$v" =~ $RELEASE_RE ]] || echo "and, for $README: scripts/set-version.sh --readme-only <latest release>" >&2
   fi
   return $rc
 }
@@ -107,7 +135,7 @@ case "${1:-}" in
     check_version
     ;;
   --readme-only)
-    [[ $# -eq 2 && "$2" =~ $VERSION_RE ]] || die "usage: $0 --readme-only X.Y.Z"
+    [[ $# -eq 2 && "$2" =~ $RELEASE_RE ]] || die "usage: $0 --readme-only X.Y.Z"
     set_readme "$2"
     ;;
   -h|--help|"")


### PR DESCRIPTION
Documentation audit against the current code and configuration. No behaviour change; the only script touched is `scripts/set-version.sh`, so that the README fix survives the `version-consistency` CI job.

**Changes**

- **README**: the `<plugin>` snippets pointed at `2.2.1-SNAPSHOT`, which is not published anywhere (Central snapshots return 404) — the post-release bump synced the README to the pom and `--check` enforced it. README is back to `2.2.0`, and `scripts/set-version.sh` now treats the root README as *latest release only*: untouched on `-SNAPSHOT` bumps, also rewrites the `mvn se.kth.castor:depclean-maven-plugin:X.Y.Z:depclean` command lines (previously unmanaged and drifting), `--check` verifies one consistent release version, `--readme-only` rejects snapshots. `release.sh prepare`/`finish` and the Deploy "Update README" step keep working unchanged.
- **README parameters**: `<failIfUnusedInherited>` does not exist; documented the real `failIfUnusedInheritedDirect` / `failIfUnusedInheritedTransitive`. `createCallGraphCsv` only writes together with `createResultJson`. The goal binds to the `package` phase (it does not run "before" it).
- **Gradle README**: real output file names (`debloated-dependencies.gradle`, `build/depclean-results.json`, `build/class-usage.csv`), a `depclean { }` DSL example, exact formats for `ignoreConfiguration` / `ignoreDependency`, fixed an unclosed backtick.
- **Javadoc** (`DepCleanMojo`, `DepCleanGradlePluginExtension`): same file-name/format corrections (`ignoreDependencies` is regex-matched).
- **SECURITY.md**: supported line `2.2.x`; alerts come from Renovate, not Dependabot.
- **CITATION.cff**: was rejected by the CFF 1.2.0 schema (`'authors' is a required property`); added the required top-level fields and fixed an ORCID with a stray space.
- **CONTRIBUTING.md**: documents the README release-version rule and `./mvnw spotless:apply`.

**Verification**

- `./mvnw -ntp clean verify` (via `clean install`) and `./gradlew clean publishToMavenLocal build`: green locally.
- `scripts/set-version.sh --check`: passes; scratch-copy scenarios for release bump, snapshot bump, injected drift (fails with hint) and `--readme-only` behave as described. `shellcheck` clean.
- `cffconvert --validate`: valid.
- Gradle README followed verbatim in a throw-away project: produces exactly the documented files.

**Noticed but out of scope** (code, not docs): `depclean-callgraph.csv` writes a 4-column header (`DepCleanManager`) while rows have 3 columns (`NodeAdapter.writeCallGraphCsv`); the enforcer's `requireJavaVersion [17,)` understates the real build floor (Checkstyle 14 needs Java 21).

Checklist: single topic, build run locally and passing, no GitHub closing keywords.
