### PR TITLE
#536 Verify and ensure depclean-maven-plugin works with Maven 4 (alongside 3.9)

### DIFF
--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -1,0 +1,36 @@
+name: Set up Apache Maven
+description: >-
+  Downloads an Apache Maven binary distribution from Maven Central, verifies its
+  SHA-512 checksum and returns its installation directory. The PATH is left untouched.
+
+inputs:
+  version:
+    description: Maven version to install, e.g. 4.0.0-rc-6
+    required: true
+
+outputs:
+  maven-home:
+    description: Installation directory of the Maven distribution (contains bin/mvn)
+    value: ${{ steps.install.outputs.maven-home }}
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        base="https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${VERSION}"
+        archive="apache-maven-${VERSION}-bin.zip"
+        install_dir="${RUNNER_TEMP}/maven-${VERSION}"
+        mkdir -p "${install_dir}"
+        cd "${install_dir}"
+        curl -fsSL --retry 3 -o "${archive}" "${base}/${archive}"
+        curl -fsSL --retry 3 -o "${archive}.sha512" "${base}/${archive}.sha512"
+        echo "$(cat "${archive}.sha512")  ${archive}" | sha512sum -c -
+        unzip -q "${archive}"
+        maven_home="${install_dir}/apache-maven-${VERSION}"
+        "${maven_home}/bin/mvn" -version
+        echo "maven-home=${maven_home}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
           distribution: "temurin"
           cache: "maven"
 
+      # The integration tests fork the wrapper's Maven 3.9.x (see it.maven.home in the plugin pom)
       - name: "Build and Verify"
         run: ./mvnw -ntp clean verify --errors
 
@@ -70,13 +71,20 @@ jobs:
   # The maven-plugin main sources target Java 8 bytecode (statically enforced by
   # enforceBytecodeVersion), while the BUILD needs JDK 21+. This job proves the
   # runtime promise: build once on JDK 25, then run the depclean goal on a
-  # Java 8 fixture with Maven running on each supported runtime JDK.
+  # Java 8 fixture with Maven running on each supported runtime JDK, and on
+  # Maven 4 (which itself needs Java 17+) at its JDK floor and on the latest JDK.
   runtime-smoke:
     strategy:
       fail-fast: false
       matrix:
         java-runtime: [8, 17, 21, 25]
-    name: Maven plugin runtime smoke test on Java ${{ matrix.java-runtime }}
+        maven: [wrapper]
+        include:
+          - java-runtime: 17
+            maven: 4.0.0-rc-6 # renovate: apache-maven
+          - java-runtime: 25
+            maven: 4.0.0-rc-6 # renovate: apache-maven
+    name: Maven plugin runtime smoke test on Java ${{ matrix.java-runtime }} with Maven ${{ matrix.maven }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -98,6 +106,13 @@ jobs:
           distribution: "temurin"
           cache: "maven"
 
+      - name: Set up Maven ${{ matrix.maven }} (runtime)
+        if: matrix.maven != 'wrapper'
+        id: runtime-maven
+        uses: ./.github/actions/setup-maven
+        with:
+          version: ${{ matrix.maven }}
+
       - name: "Build and install plugin (JDK 25)"
         run: ./mvnw -ntp clean install -DskipTests -q
 
@@ -105,14 +120,16 @@ jobs:
         id: version
         run: echo "version=$(./mvnw -ntp -q -DforceStdout help:evaluate -Dexpression=project.version)" >> "$GITHUB_OUTPUT"
 
-      - name: "Run DepClean on the fixture with Maven on JDK ${{ matrix.java-runtime }}"
+      - name: "Run DepClean on the fixture with Maven ${{ matrix.maven }} on JDK ${{ matrix.java-runtime }}"
         env:
           JAVA_HOME: ${{ env[format('JAVA_HOME_{0}_X64', matrix.java-runtime)] }}
+          MVN: ${{ matrix.maven == 'wrapper' && './mvnw' || format('{0}/bin/mvn', steps.runtime-maven.outputs.maven-home) }}
         run: |
-          ./mvnw -version
-          ./mvnw -ntp -f .github/smoke/java8/pom.xml \
+          "$MVN" -version
+          "$MVN" -ntp -f .github/smoke/java8/pom.xml \
             package se.kth.castor:depclean-maven-plugin:${{ steps.version.outputs.version }}:depclean \
             | tee /tmp/depclean-smoke.log
+          # Maven 4 prefixes the plugin's stdout with "[INFO] [stdout] ", hence substring matches
           grep 'D E P C L E A N   A N A L Y S I S   R E S U L T S' /tmp/depclean-smoke.log
           grep -A2 'USED DIRECT DEPENDENCIES \[1\]' /tmp/depclean-smoke.log | grep 'commons-io:commons-io'
           grep -A2 'POTENTIALLY UNUSED DIRECT DEPENDENCIES \[1\]' /tmp/depclean-smoke.log | grep 'org.apache.commons:commons-lang3'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ cd depclean-gradle-plugin
 
 - Unit tests run with `./mvnw test`.
 - The Maven plugin has integration tests (`DepCleanMojoIT`) that execute real Maven builds against fixture projects under `depclean-maven-plugin/src/test/resources-its`. Their assertions compare against golden log output, which embeds exact dependency versions and jar sizes — if you change a fixture, update the expected output from the actual logs under `depclean-maven-plugin/target/maven-it/`.
+- By default the integration tests fork the same Maven that runs the build (the wrapper's 3.9.x). To run them against another Maven distribution, e.g. Maven 4, point `it.maven.home` at its installation directory: `./mvnw clean verify -Dit.maven.home=/opt/apache-maven-4.0.0-rc-6`. CI only smoke-tests the plugin on the Maven 4 version listed in [build.yml](.github/workflows/build.yml), so run this locally when touching the Maven integration.
 - Coverage is collected with JaCoCo and reported to [Codecov](https://codecov.io/gh/ASSERT-KTH/depclean).
 
 ## Submitting a pull request

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For a visual overview of how DepClean works and what it can do for your project,
 
 ## Usage
 
-DepClean requires Maven 3.9+ and runs on any JVM from Java 8 upwards, regardless of the Java version your project targets.
+DepClean requires Maven 3.9 or newer — including Maven 4, against which it is tested in CI (currently 4.0.0-rc-6) — and runs on any JVM from Java 8 upwards, regardless of the Java version your project targets. Note that Maven 4 itself needs Java 17 or newer.
 
 Configure the `pom.xml` file of your Maven project to use DepClean as part of the build:
 

--- a/depclean-core/pom.xml
+++ b/depclean-core/pom.xml
@@ -24,7 +24,6 @@
     <!-- Dependencies -->
     <asm.version>9.10.1</asm.version>
     <guava.version>33.7.1-jre</guava.version>
-    <plexus-component-annotations.version>2.2.0</plexus-component-annotations.version>
     <plexus-utils.version>4.1.0</plexus-utils.version>
     <qdox.version>2.2.0</qdox.version>
 
@@ -48,23 +47,11 @@
       <version>${asm.version}</version>
     </dependency>
 
-    <!-- Maven dependencies -->
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-component-annotations</artifactId>
-      <version>${plexus-component-annotations.version}</version>
-      <scope>compile</scope>
-    </dependency>
+    <!-- Directory scanning (DirectoryScanner) -->
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
       <version>${plexus-utils.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <version>${maven-core.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -24,6 +24,7 @@
     <!-- Dependencies -->
     <gson.version>2.14.0</gson.version>
     <itf-jupiter-extension.version>0.13.1</itf-jupiter-extension.version>
+    <javax.inject.version>1</javax.inject.version>
     <maven-dependency-tree-parser.version>1.0.6</maven-dependency-tree-parser.version>
     <maven-dependency-tree.version>3.3.0</maven-dependency-tree.version>
     <maven-plugin-annotations.version>3.15.2</maven-plugin-annotations.version>
@@ -35,6 +36,10 @@
 
     <!-- Build settings -->
     <checkstyle.config.location>../checkstyle.xml</checkstyle.config.location>
+    <!-- Maven distribution the integration tests run the plugin on. Defaults to the Maven
+         running this build; point it elsewhere to test another version, e.g.
+         `./mvnw verify -Dit.maven.home=/opt/apache-maven-4.0.0` -->
+    <it.maven.home>${maven.home}</it.maven.home>
     <sonar.coverage.jacoco.xmlReportPaths>
       target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
@@ -66,6 +71,13 @@
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>${maven-plugin-annotations.version}</version>
+    </dependency>
+    <!-- JSR-330 injection of Maven components into the mojo; provided by the Maven runtime -->
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>${javax.inject.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
@@ -177,6 +189,11 @@
           <environmentVariables>
             <MAVEN_OPTS>${itCoverageAgent}</MAVEN_OPTS>
           </environmentVariables>
+          <systemPropertyVariables>
+            <!-- The ITF extension forks the Maven found via this property (before falling back
+                 to MAVEN_HOME and the PATH), so the ITs exercise the plugin on ${it.maven.home}. -->
+            <maven.home>${it.maven.home}</maven.home>
+          </systemPropertyVariables>
         </configuration>
         <executions>
           <execution>

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
@@ -19,10 +19,10 @@ package se.kth.depclean;
 
 import java.io.IOException;
 import java.util.Set;
+import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -144,7 +144,7 @@ public class DepCleanMojo extends AbstractMojo {
   private boolean skipDepClean;
 
   /** To build the dependency graph. */
-  @Component(hint = "default")
+  @Inject
   @SuppressWarnings("NullAway") // Injected by Maven
   private DependencyGraphBuilder dependencyGraphBuilder;
 

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenDebloater.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/util/MavenDebloater.java
@@ -2,9 +2,12 @@ package se.kth.depclean.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import org.apache.maven.artifact.Artifact;
@@ -39,7 +42,8 @@ public class MavenDebloater extends AbstractDebloater<Dependency> {
     super(analysis);
     this.project = project;
     this.model = model;
-    this.initialDependencies = model.getDependencies();
+    // Snapshot: on Maven 4 the model hands out a live view that follows setDependencies().
+    this.initialDependencies = new ArrayList<>(model.getDependencies());
   }
 
   @Override
@@ -128,7 +132,9 @@ public class MavenDebloater extends AbstractDebloater<Dependency> {
    */
   private void writePom(final Path pomFile) throws IOException {
     MavenXpp3Writer writer = new MavenXpp3Writer();
-    writer.write(Files.newBufferedWriter(pomFile), model);
+    try (Writer out = Files.newBufferedWriter(pomFile, StandardCharsets.UTF_8)) {
+      writer.write(out, model);
+    }
   }
 
   private Artifact findArtifact(se.kth.depclean.core.model.Dependency dependency) {

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/wrapper/MavenDependencyManager.java
@@ -5,10 +5,8 @@ import fr.dutra.tools.maven.deptree.core.ParseException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.io.InputStream;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -142,11 +140,11 @@ public class MavenDependencyManager implements DependencyManagerWrapper {
 
     /* Build Maven model to manipulate the pom */
     final Model builtModel;
-    Reader reader;
     MavenXpp3Reader mavenReader = new MavenXpp3Reader();
-    try {
-      reader = new InputStreamReader(new FileInputStream(pomFile), StandardCharsets.UTF_8);
-      builtModel = mavenReader.read(reader);
+    // Hand the raw stream to the parser: given a Reader, Maven 4's StAX-based reader records the
+    // Java charset name ("UTF8") as the model encoding, which then ends up in the debloated pom.
+    try (InputStream in = new FileInputStream(pomFile)) {
+      builtModel = mavenReader.read(in);
       builtModel.setPomFile(pomFile);
     } catch (Exception ex) {
       getLog().error("Unable to build the maven project.");

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanMojoIT.java
@@ -7,8 +7,19 @@ import com.soebes.itf.jupiter.extension.MavenTest;
 import com.soebes.itf.jupiter.maven.MavenExecutionResult;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.assertj.core.api.ListAssert;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.slf4j.Logger;
@@ -30,6 +41,33 @@ public class DepCleanMojoIT {
 
   private static final Logger log = LoggerFactory.getLogger(DepCleanMojoIT.class);
 
+  /**
+   * Maven 4 routes everything a plugin writes to standard output through its logger, so each line
+   * of the DepClean report arrives as {@code [INFO] [stdout] <line>} there, whereas Maven 3 passes
+   * it through verbatim.
+   */
+  private static final String MAVEN_4_STDOUT_PREFIX = "[INFO] [stdout] ";
+
+  /** Asserts that the build succeeded and returns its standard output, normalized across Maven versions. */
+  private static ListAssert<String> assertThatStdout(MavenExecutionResult result) {
+    assertThat(result).isSuccessful();
+    try {
+      List<String> lines =
+          Files.readAllLines(result.getMavenLog().getStdout(), StandardCharsets.UTF_8).stream()
+              .map(DepCleanMojoIT::withoutStdoutPrefix)
+              .collect(Collectors.toList());
+      return assertThat(lines);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static String withoutStdoutPrefix(String line) {
+    return line.startsWith(MAVEN_4_STDOUT_PREFIX)
+        ? line.substring(MAVEN_4_STDOUT_PREFIX.length())
+        : line;
+  }
+
   @MavenTest
   void empty_project(MavenExecutionResult result) {
     log.trace("Test that DepClean runs in an empty Maven project");
@@ -39,10 +77,7 @@ public class DepCleanMojoIT {
   @MavenTest
   void used_java_record(MavenExecutionResult result) {
     log.trace("Test that DepClean identifies dependency used in Java record");
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "-------------------------------------------------------",
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",
@@ -66,10 +101,7 @@ public class DepCleanMojoIT {
     log.trace(
         "Test that DepClean does not crash when dependency coordinates use property placeholders"
             + " (issue #399)");
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "-------------------------------------------------------",
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",
@@ -89,10 +121,7 @@ public class DepCleanMojoIT {
     // shared call graph between the analyses, the classes used by the first module are still
     // reachable when the second module is analyzed, so commons-io would be wrongly reported as
     // used there, and the first two lines asserted below would not be printed at all.
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "USED DIRECT DEPENDENCIES [0]: ",
             "POTENTIALLY UNUSED DIRECT DEPENDENCIES [1]: ",
@@ -104,10 +133,7 @@ public class DepCleanMojoIT {
     log.trace(
         "Test that a dependency only referenced in a Spring XML configuration is considered used"
             + " (issue #78)");
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "-------------------------------------------------------",
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",
@@ -131,10 +157,7 @@ public class DepCleanMojoIT {
     log.trace(
         "Test that a dependency only referenced in WEB-INF/web.xml is considered used"
             + " (issue #81)");
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "-------------------------------------------------------",
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",
@@ -150,10 +173,7 @@ public class DepCleanMojoIT {
   @MavenTest
   void all_dependencies_unused(MavenExecutionResult result) {
     log.trace("Test that DepClean identifies all dependencies as unused");
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "-------------------------------------------------------",
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",
@@ -181,10 +201,7 @@ public class DepCleanMojoIT {
   @MavenTest
   void all_dependencies_used(MavenExecutionResult result) {
     log.trace("Test that DepClean identifies all dependencies as used");
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "-------------------------------------------------------",
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",
@@ -207,10 +224,7 @@ public class DepCleanMojoIT {
   @MavenTest
   void used_indirectly(MavenExecutionResult result) {
     log.trace("Test that dependencies used indirectly (org.tukaani:xz is used indirectly)");
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "-------------------------------------------------------",
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",
@@ -233,10 +247,7 @@ public class DepCleanMojoIT {
   @MavenTest
   void processor_used(MavenExecutionResult result) {
     log.trace("Test that DepClean runs in a Maven project with processors");
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "-------------------------------------------------------",
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",
@@ -279,15 +290,13 @@ public class DepCleanMojoIT {
   }
 
   @MavenTest
-  void debloated_pom_is_correct(MavenExecutionResult result) {
+  void debloated_pom_is_correct(MavenExecutionResult result)
+      throws IOException, XmlPullParserException {
     log.trace("Test that DepClean creates a proper pom-debloated.xml file");
     String path =
         "target/maven-it/se/kth/depclean/DepCleanMojoIT/debloated_pom_is_correct/project/pom-debloated.xml";
     File generatedPomDebloated = new File(path);
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "[INFO] Starting debloating POM file...",
             "[INFO] Adding 1 used transitive dependency as direct dependency.",
@@ -301,9 +310,23 @@ public class DepCleanMojoIT {
             "[INFO] pom-debloated.xml file created in: "
                 + generatedPomDebloated.getAbsolutePath());
     Assertions.assertTrue(generatedPomDebloated.exists());
-    assertThat(generatedPomDebloated)
-        .hasSameTextualContentAs(
-            new File("src/test/resources/DepCleanMojoResources/pom-debloated.xml"));
+    assertThat(normalizedPom(generatedPomDebloated))
+        .isEqualTo(
+            normalizedPom(new File("src/test/resources/DepCleanMojoResources/pom-debloated.xml")));
+  }
+
+  /**
+   * Re-serializes a pom with the model writer on the test classpath. Maven 3 and Maven 4 format
+   * the written pom differently (attribute order, property order), so the raw text cannot be
+   * compared across the Maven versions the ITs run on, whereas the model content can.
+   */
+  private static String normalizedPom(File pom) throws IOException, XmlPullParserException {
+    try (InputStream in = Files.newInputStream(pom.toPath())) {
+      Model model = new MavenXpp3Reader().read(in);
+      StringWriter out = new StringWriter();
+      new MavenXpp3Writer().write(out, model);
+      return out.toString();
+    }
   }
 
   @MavenTest
@@ -311,10 +334,7 @@ public class DepCleanMojoIT {
   void unused_inherited_exists(MavenExecutionResult result) {
     log.trace(
         "Test that DepClean detects unused inherited dependencies in a Maven project with a parent");
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "-------------------------------------------------------",
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",
@@ -348,10 +368,7 @@ public class DepCleanMojoIT {
   void ignored_scopes(MavenExecutionResult result) {
     log.trace(
         "Test that DepClean ignores dependencies (considers them as used) with the ignored scopes");
-    assertThat(result)
-        .isSuccessful()
-        .out()
-        .plain()
+    assertThatStdout(result)
         .contains(
             "-------------------------------------------------------",
             " D E P C L E A N   A N A L Y S I S   R E S U L T S",

--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,17 @@
     "description": "Security fixes skip the cooldown and get merged immediately",
     "minimumReleaseAge": null
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Maven 4 distribution the CI runs the plugin on (build.yml matrix entries tagged '# renovate: apache-maven')",
+      "managerFilePatterns": ["/^\\.github/workflows/build\\.yml$/"],
+      "matchStrings": ["maven: (?<currentValue>\\S+) # renovate: apache-maven"],
+      "datasourceTemplate": "maven",
+      "depNameTemplate": "org.apache.maven:apache-maven",
+      "versioningTemplate": "maven"
+    }
+  ],
   "osvVulnerabilityAlerts": true,
   "platformAutomerge": true,
   "forkProcessing": "enabled",


### PR DESCRIPTION
#536 Maven 4 compatibility for depclean-maven-plugin

Verified against Maven 4.0.0-rc-6 (latest on Central; there is no GA yet) while keeping Maven 3.9.x fully supported. The full IT suite is green on both 3.9.16 and 4.0.0-rc-6, and `-Dmaven.plugin.validation=verbose` reports no issues on either.

This branch is meant to stay open until Maven 4 goes GA; Renovate is wired up to bump the CI's Maven 4 version as new RCs / the GA land.

### Findings on Maven 4

The analysis results are identical on both versions. What broke was around the debloated pom and the test harness:

* `MavenDebloater` kept `model.getDependencies()` as the "initial" dependency list. On Maven 4 this is a live view over the immutable v4 model, so after `setDependencies()` it no longer reflected the original declarations and `${property}` versions were lost in `pom-debloated.xml`. Fixed by snapshotting the list.
* `MavenXpp3Reader.read(Reader)` on Maven 4 records the Java charset name (`UTF8`) as the model encoding, which then ends up in the XML declaration of the debloated pom. Fixed by handing the raw `InputStream` to the parser.
* Maven 4 routes a plugin's `System.out` through its logger (`[INFO] [stdout] ` prefix) and its model writer orders attributes/properties differently; the ITs now normalize both.

### Changes

* Replace the deprecated `@Component` injection of `DependencyGraphBuilder` with JSR-330 `@Inject` (supported since Maven 3.1); `javax.inject` added as `provided`.
* ITs fork the Maven running the build by default (previously: whatever `mvn` was on the PATH); `-Dit.maven.home=<dir>` points them at another distribution, e.g. Maven 4.
* `depclean-core`: drop the unused `maven-core` and `plexus-component-annotations` dependencies (only `plexus-utils`' `DirectoryScanner` is used). Removes a Maven-3.9-pinned tree of ~30 jars from every consumer, including the Gradle plugin.
* CI: the `runtime-smoke` job gains two legs running the goal on Maven 4.0.0-rc-6 with JDK 17 and 25, installed via a local composite action (checksum-verified download from Central). The regular build matrix is unchanged, so this adds only two short smoke jobs.
* README: supported Maven range; CONTRIBUTING: how to run the ITs against another Maven.

### Left as-is (deprecated in Maven 4, but the only APIs available on both 3.9 and 4)

`MavenXpp3Reader`/`Writer`, `ProjectBuildingRequest` (required by `maven-dependency-tree` 3.3.0), `project.getDependencyArtifacts()`, `Xpp3Dom` casts. Moving off them means the Maven 4 API only, i.e. dropping 3.9.

### Verification

* `./mvnw clean verify` (Maven 3.9.16): 68 core + 16 plugin unit tests, 14 ITs, Checkstyle clean
* `./mvnw verify -Dit.maven.home=/tmp/apache-maven-4.0.0-rc-6`: 14 ITs green on Maven 4
* `./gradlew clean publishToMavenLocal build` in `depclean-gradle-plugin`: green
* Smoke fixture on Maven 4 with `-Dmaven.plugin.validation=verbose`: no plugin issues
