### PR TITLE
perf: traverse the call graph once and cut per-entry file-system work when extracting jars (#79)

### DIFF
--- a/depclean-core/src/main/java/se/kth/depclean/core/DepCleanManager.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/DepCleanManager.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -88,12 +89,17 @@ public class DepCleanManager {
       return null;
     }
 
+    long phaseStart = System.currentTimeMillis();
     extractClassesFromDependencies();
+    phaseStart = logPhase("Extracting dependency classes", phaseStart);
+
+    final ProjectContext projectContext = buildProjectContext();
+    phaseStart = logPhase("Building project context", phaseStart);
 
     final DefaultProjectDependencyAnalyzer projectDependencyAnalyzer =
         new DefaultProjectDependencyAnalyzer();
-    final ProjectDependencyAnalysis analysis =
-        projectDependencyAnalyzer.analyze(buildProjectContext());
+    final ProjectDependencyAnalysis analysis = projectDependencyAnalyzer.analyze(projectContext);
+    phaseStart = logPhase("Analyzing bytecode", phaseStart);
     analysis.print();
 
     /* Fail the build if there are unused direct dependencies */
@@ -122,12 +128,16 @@ public class DepCleanManager {
 
     /* Writing the debloated version of the pom */
     if (createPomDebloated) {
+      phaseStart = System.currentTimeMillis();
       dependencyManager.getDebloater(analysis).write();
+      logPhase("Writing debloated pom", phaseStart);
     }
 
     /* Writing the JSON file with the depclean results */
     if (createResultJson) {
+      phaseStart = System.currentTimeMillis();
       createResultJson(analysis);
+      logPhase("Writing result files", phaseStart);
     }
 
     final long stopTime = System.currentTimeMillis();
@@ -307,6 +317,13 @@ public class DepCleanManager {
     long minutes = TimeUnit.MILLISECONDS.toMinutes(millis);
     long seconds = (TimeUnit.MILLISECONDS.toSeconds(millis) % 60);
     return String.format("%smin %ss", minutes, seconds);
+  }
+
+  /** Logs the duration of a phase that started at {@code start} and returns the current time. */
+  private long logPhase(String phase, long start) {
+    final long now = System.currentTimeMillis();
+    getLog().info(String.format(Locale.ROOT, "%s took %.1fs", phase, (now - start) / 1000.0));
+    return now;
   }
 
   private void printString(final String string) {

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/ProjectDependencyAnalysisBuilder.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/ProjectDependencyAnalysisBuilder.java
@@ -34,8 +34,8 @@ public class ProjectDependencyAnalysisBuilder {
             .flatMap(clazz -> context.getDependenciesForClass(clazz).stream())
             .collect(Collectors.toSet());
 
-    log.debug("Actual used classes: " + actualUsedClasses.getRegisteredClasses());
-    log.debug("Used dependencies" + usedDependencies);
+    log.debug("Actual used classes: {}", actualUsedClasses.getRegisteredClasses());
+    log.debug("Used dependencies {}", usedDependencies);
   }
 
   /**

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DependencyClassFileVisitor.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/asm/DependencyClassFileVisitor.java
@@ -71,7 +71,8 @@ public class DependencyClassFileVisitor implements ClassFileVisitor {
           new DefaultClassVisitor(
               signatureVisitor, annotationVisitor, fieldVisitor, methodVisitor, resultCollector);
 
-      reader.accept(defaultClassVisitor, 0);
+      // Stack map frames are never visited (no visitFrame override), so skip decoding them.
+      reader.accept(defaultClassVisitor, ClassReader.SKIP_FRAMES);
 
       // inset edge in the graph based on the bytecode analysis
       DefaultCallGraph.addEdge(className, resultCollector.getDependencies());

--- a/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/analysis/graph/DefaultCallGraph.java
@@ -67,25 +67,22 @@ public class DefaultCallGraph {
    * @return All the referenced classes.
    */
   public static Set<String> referencedClassMembers(Set<String> projectClasses) {
-    log.debug("Project classes: " + projectClasses);
-    Set<String> allReferencedClassMembers = new HashSet<>();
-    for (String projectClass : projectClasses) {
-      allReferencedClassMembers.addAll(traverse(projectClass));
-    }
-    log.debug("All referenced class members: " + allReferencedClassMembers);
+    log.debug("Project classes: {}", projectClasses);
+    // One multi-source traversal: the union of per-class reachability with a shared visited set.
+    Set<String> allReferencedClassMembers = traverse(projectClasses);
+    log.debug("All referenced class members: {}", allReferencedClassMembers);
     return allReferencedClassMembers;
   }
 
   /**
-   * Traverse the graph using DFS.
+   * Traverse the graph using DFS from several starting vertices.
    *
-   * @param start The starting vertex.
+   * @param starts The starting vertices.
    * @return The set of all visited vertices.
    */
-  private static Set<String> traverse(String start) {
+  private static Set<String> traverse(Set<String> starts) {
     Set<String> visited = new HashSet<>();
-    Deque<String> stack = new ArrayDeque<>();
-    stack.push(start);
+    Deque<String> stack = new ArrayDeque<>(starts);
     while (!stack.isEmpty()) {
       String current = stack.pop();
       if (visited.add(current)) {

--- a/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
@@ -22,8 +22,11 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.apache.commons.io.FileUtils;
@@ -72,7 +75,12 @@ public final class JarUtils {
     File file = new File(zipFile);
     try (ZipFile zip = new ZipFile(file)) {
       String newPath = zipFile.substring(0, zipFile.length() - 4);
-      new File(newPath).mkdir();
+      File targetDirectory = new File(newPath);
+      targetDirectory.mkdir();
+      // Canonicalize once: the directory was just created, so every entry path below it is only
+      // subject to "../" traversal, which normalize() resolves without hitting the file system.
+      Path canonicalTarget = targetDirectory.getCanonicalFile().toPath();
+      Set<File> createdDirectories = new HashSet<>();
       Enumeration<? extends ZipEntry> zipFileEntries = zip.entries();
 
       // Protection against ZIP bomb attacks
@@ -94,14 +102,16 @@ public final class JarUtils {
           continue;
         }
 
-        File destFile = new File(newPath, currentEntry);
+        File destFile = new File(canonicalTarget.toFile(), currentEntry);
         // Sonar javasecurity:S6096
-        if (!destFile.getCanonicalPath().startsWith(new File(newPath).getCanonicalPath())) {
+        if (!destFile.toPath().normalize().startsWith(canonicalTarget)) {
           throw new IOException("Entry is outside of the target directory");
         }
         File destinationParent = destFile.getParentFile();
         // create the parent directory structure if needed
-        destinationParent.mkdirs();
+        if (createdDirectories.add(destinationParent)) {
+          destinationParent.mkdirs();
+        }
         if (!entry.isDirectory() && !destFile.isDirectory()) {
           totalSizeUncompressed +=
               extractEntry(zip, entry, destFile, totalSizeUncompressed, maxTotalSize);

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/graph/MavenDependencyGraph.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/graph/MavenDependencyGraph.java
@@ -63,10 +63,10 @@ public class MavenDependencyGraph implements DependencyGraph {
         inheritedTransitiveDependencies(inheritedDirectDependencies, new HashSet<>());
     this.transitiveDependencies = transitiveDependencies(allDependencies);
 
-    log.debug("Direct dependencies" + directDependencies);
-    log.debug("Inherited direct dependencies" + inheritedDirectDependencies);
-    log.debug("Inherited transitive dependencies" + inheritedTransitiveDependencies);
-    log.debug("Transitive dependencies" + transitiveDependencies);
+    log.debug("Direct dependencies {}", directDependencies);
+    log.debug("Inherited direct dependencies {}", inheritedDirectDependencies);
+    log.debug("Inherited transitive dependencies {}", inheritedTransitiveDependencies);
+    log.debug("Transitive dependencies {}", transitiveDependencies);
 
     // Logs
     if (log.isDebugEnabled()) {


### PR DESCRIPTION
## Summary

Profiles the `depclean` goal on large projects (#79) and fixes the two hot spots the profile actually pointed at. The debloated-pom writer and the dependency-graph construction, suspected in the issue, turned out to be below 2% of the wall time.

## Method

- async-profiler 4.5 in wall-clock mode attached to Maven (`-agentpath:...=start,event=wall,interval=10ms`), samples attributed relative to `DepCleanManager.execute`.
- Target: Apache Accumulo @ `85796e5` (the commit from the issue), JDK 17, modules `core` (~150 artifacts) and `test` (~84k dependency classes, 420 verbose tree nodes), run with the exact flags from the issue (`-DignoreScopes=provided,test,runtime,system,import`).

Baseline attribution (`accumulo-test`):

| frame (inclusive) | % of `execute` |
|---|---|
| `DefaultProjectDependencyAnalyzer.analyze` | 71% |
| ↳ `DefaultCallGraph.referencedClassMembers` | **57%** |
| ↳ ASM `DependencyClassFileVisitor.visitClass` | 11% |
| `DepCleanManager.extractClassesFromDependencies` | 27% |
| ↳ `JarUtils.decompress` (top self frames: `readlink`, `open`, `mkdir`) | **26%** |
| `buildProjectContext` (incl. dependency graph) | 2% |
| `AbstractDebloater.write` | <0.1% |

## Changes

- **`DefaultCallGraph.referencedClassMembers`** ran a full DFS with a *fresh* visited set for every project class, i.e. O(classes × edges). It now traverses once from all project classes with a shared visited set. The result is the same union of reachable vertices.
- **`JarUtils.decompressDependencyFiles`** called `getCanonicalPath()` twice per zip entry (once for the entry, once for the target directory) and `mkdirs()` per entry. The target directory is canonicalized once per archive; entries are checked with `Path.normalize().startsWith(target)` (component-wise, so it is also stricter than the previous string prefix check); `mkdirs` is skipped for parents already created for that archive.
- **`DependencyClassFileVisitor`**: read classes with `ClassReader.SKIP_FRAMES` — none of the visitors override `visitFrame`, so stack-map frames were decoded for nothing.
- **`DepCleanManager`**: log per-phase durations at INFO (`Extracting dependency classes took 10.0s`, …) so future reports on #79 can say where the time goes.
- Parameterized debug logging for large collections that were concatenated eagerly regardless of log level.

## Results

Same machine, same flags, analysis output byte-identical (diffed the printed report for both modules):

| module | before | after |
|---|---|---|
| accumulo `core` | 25s | 16s |
| accumulo `test` | 46s | 21s |

After the change the remaining floor is jar extraction to `target/dependency` (~86k files; `open`/`mkdir`/`unlink` syscalls). Removing that would mean analysing jars in place instead of extracting them, which changes what the goal leaves behind on disk — left for a follow-up.

## Notes for #79

The hours reported in the issue are not reproducible per module with current `master` (nor with 2.0.6: 47s / 80s on the same modules here). What did happen with 2.0.6 in a reactor build was that `DefaultCallGraph` kept its static state across modules (fixed in #479), and every module then paid the quadratic traversal above over the ever-growing graph — matching the per-module times in the report climbing from minutes to hours as the reactor progressed.

While profiling I also found that `-DcreateCallGraphCsv=true` writes the entire edge list once per dependency-tree node (8.7 GB and still growing after 5 minutes on `accumulo-test`). That is a separate defect and is addressed in its own PR.

## Verification

- `./mvnw -ntp clean verify --errors` (checkstyle, ErrorProne/NullAway, unit tests, ITs) green on JDK 25.
