### PR TITLE
fix(core): extract jars with more than 10k entries instead of flagging them as ZIP bombs

### DIFF
--- a/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/model/Dependency.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import se.kth.depclean.core.analysis.ClassAnalyzer;
 import se.kth.depclean.core.analysis.DefaultClassAnalyzer;
+import se.kth.depclean.core.util.JarUtils;
 
 /** Identifies a dependency to analyse. */
 public class Dependency {
@@ -157,7 +158,7 @@ public class Dependency {
       Enumeration<JarEntry> jarEntries = jarFile.entries();
 
       // Protection against ZIP bomb attacks
-      int maxEntries = 100_000; // Maximum number of entries to process
+      int maxEntries = JarUtils.MAX_ENTRIES;
       int entryCount = 0;
 
       while (jarEntries.hasMoreElements() && entryCount < maxEntries) {

--- a/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
+++ b/depclean-core/src/main/java/se/kth/depclean/core/util/JarUtils.java
@@ -41,6 +41,13 @@ public final class JarUtils {
   /** Size of the buffer to read/write data. */
   private static final int BUFFER_SIZE = 16384;
 
+  /**
+   * Upper bound on the entries extracted from one archive. Shaded and uber jars routinely exceed
+   * 10k entries, so this matches the limit the class listing applies (see {@code Dependency}); the
+   * actual ZIP-bomb protection is the total-size and compression-ratio check per entry.
+   */
+  public static final int MAX_ENTRIES = 100_000;
+
   private JarUtils() {}
 
   /**
@@ -84,14 +91,13 @@ public final class JarUtils {
       Enumeration<? extends ZipEntry> zipFileEntries = zip.entries();
 
       // Protection against ZIP bomb attacks
-      int maxEntries = 10_000; // Maximum number of entries to process
       long maxTotalSize = 1_000_000_000L; // 1 GB maximum total uncompressed size
 
       int entryCount = 0;
       long totalSizeUncompressed = 0;
 
       // Process each entry
-      while (zipFileEntries.hasMoreElements() && entryCount < maxEntries) {
+      while (zipFileEntries.hasMoreElements() && entryCount < MAX_ENTRIES) {
         // grab a zip file entry
         ZipEntry entry = zipFileEntries.nextElement();
         String currentEntry = entry.getName();
@@ -126,7 +132,7 @@ public final class JarUtils {
       }
 
       // Check if processing was truncated due to too many entries
-      if (entryCount >= maxEntries) {
+      if (entryCount >= MAX_ENTRIES) {
         throw new IOException(
             "ZIP bomb detected: too many entries in archive (" + entryCount + ")");
       }

--- a/depclean-core/src/test/java/se/kth/depclean/core/util/JarUtilsTest.java
+++ b/depclean-core/src/test/java/se/kth/depclean/core/util/JarUtilsTest.java
@@ -1,16 +1,23 @@
 package se.kth.depclean.core.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,6 +129,28 @@ class JarUtilsTest {
           new File(
                   "src/test/resources/JarUtilsResources_copy/jlibrary-ear-1.2/jlibrary/WEB-INF/lib/jcr-1.0/javax/jcr/Item.class")
               .exists());
+    }
+  }
+
+  @Test
+  @DisplayName("A legitimate jar with more than 10k entries is extracted completely")
+  void whenJarHasManyEntries_thenAllEntriesAreExtracted(@TempDir Path tempDir) throws IOException {
+    // shaded jars such as testcontainers (12.5k) or hadoop-client-runtime (20k) are this size
+    int entries = 12_000;
+    Path jar = tempDir.resolve("big.jar");
+    try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(jar))) {
+      for (int i = 0; i < entries; i++) {
+        out.putNextEntry(new ZipEntry("pkg/sub" + (i % 100) + "/Class" + i + ".class"));
+        out.write(new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE});
+        out.closeEntry();
+      }
+    }
+
+    JarUtils.decompress(tempDir.toString());
+
+    assertFalse(Files.exists(jar), "the jar is deleted once extracted");
+    try (Stream<Path> files = Files.walk(tempDir.resolve("big"))) {
+      assertEquals(entries, files.filter(p -> p.toString().endsWith(".class")).count());
     }
   }
 }


### PR DESCRIPTION
## Summary

Legitimate jars with more than 10,000 entries were rejected as ZIP bombs half-way through extraction, silently truncating the bytecode analysis. Found while profiling the Maven and Gradle plugins on spring-petclinic and Apache Accumulo (#541, #543).

## Problem

`JarUtils.decompressDependencyFiles` capped extraction at **10,000 entries** and then threw `ZIP bomb detected: too many entries`. Shaded/uber jars are routinely larger:

| jar | entries |
|---|---|
| `org.testcontainers:testcontainers:2.0.5` (petclinic) | 12,566 |
| `org.apache.hadoop:hadoop-client-runtime:3.3.5` (accumulo) | 19,706 |
| `org.apache.hadoop:hadoop-client-minicluster:3.3.5` (accumulo) | 20,170 |

`JarUtils.decompress` catches the exception, logs a warning, and continues — but by then the jar is **partially extracted** (on petclinic 9,373 of testcontainers' 11,841 classes). Those classes never reach the ASM pass, so any call-graph edge originating in them is lost, while `Dependency.addClassesFromJar` (cap: 100,000) still lists them as the dependency's classes. Result: dependencies reachable only through the missing classes can be reported as "potentially unused". Both plugins share this code path. Introduced with the Sonar-driven hardening in `de2cd8f`.

## Fix

- One shared constant `JarUtils.MAX_ENTRIES = 100_000`, used by both the extraction and `Dependency`'s class listing, so the two can no longer disagree.
- The real ZIP-bomb guards — 1 GB total uncompressed size and 100:1 per-entry compression ratio — are untouched.
- New `JarUtilsTest` case: generates a 12k-entry jar, extracts it, asserts every entry is on disk and the archive was removed.

## Verification

- `./mvnw -ntp clean verify --errors` green.
- petclinic / accumulo-test runs no longer log `Problem decompressing jar file` for the jars above.
