### PR TITLE
perf(gradle-plugin): stop recomputing the dependency class map and write the class-usage CSV once per dependency

### DIFF
--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/analysis/DefaultGradleProjectDependencyAnalyzer.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/analysis/DefaultGradleProjectDependencyAnalyzer.java
@@ -54,6 +54,9 @@ public class DefaultGradleProjectDependencyAnalyzer implements GradleProjectDepe
   /** A map [artifact] -> [usedTypes]. */
   private final Map<ResolvedArtifact, Set<String>> artifactUsedClassesMap = new HashMap<>();
 
+  /** Lazily computed from the two maps above, see {@link #getDependenciesClassesMap()}. */
+  @Nullable private Map<String, DependencyTypes> dependenciesClassesMap;
+
   /** Ctor. */
   public DefaultGradleProjectDependencyAnalyzer(final boolean isIgnoredTest) {
     this.isIgnoredTest = isIgnoredTest;
@@ -85,6 +88,7 @@ public class DefaultGradleProjectDependencyAnalyzer implements GradleProjectDepe
 
       // a map of [dependency] -> [classes]
       artifactClassesMap = buildArtifactClassMap(allArtifacts);
+      dependenciesClassesMap = null;
 
       // direct dependencies of the project
       Set<ResolvedDependency> declaredDependencies = utils.getDeclaredDependencies(configurations);
@@ -294,36 +298,22 @@ public class DefaultGradleProjectDependencyAnalyzer implements GradleProjectDepe
   private Set<ResolvedArtifact> collectUsedArtifacts(
       final Map<ResolvedArtifact, Set<String>> artifactClassMap,
       final Set<String> referencedClasses) {
+    // Invert the map once; the first artifact declaring a class wins, as in the previous scan.
+    Map<String, ResolvedArtifact> artifactByClass = new HashMap<>();
+    for (Map.Entry<ResolvedArtifact, Set<String>> entry : artifactClassMap.entrySet()) {
+      for (String className : entry.getValue()) {
+        artifactByClass.putIfAbsent(className, entry.getKey());
+      }
+    }
     Set<ResolvedArtifact> usedArtifacts = new HashSet<>();
     for (String clazz : referencedClasses) {
-      ResolvedArtifact artifact = findArtifactForClassName(artifactClassMap, clazz);
-      if (findArtifactForClassName(artifactClassMap, clazz) != null) {
-        if (!artifactUsedClassesMap.containsKey(artifact)) {
-          artifactUsedClassesMap.put(artifact, new HashSet<>());
-        }
-        artifactUsedClassesMap.get(artifact).add(clazz);
+      ResolvedArtifact artifact = artifactByClass.get(clazz);
+      if (artifact != null) {
+        artifactUsedClassesMap.computeIfAbsent(artifact, k -> new HashSet<>()).add(clazz);
         usedArtifacts.add(artifact);
       }
     }
     return usedArtifacts;
-  }
-
-  /**
-   * Utility method to find whether a provided key is present in the map or not.
-   *
-   * @param artifactClassMap The map
-   * @param className The String (Expected key)
-   * @return Key if it is present otherwise null.
-   */
-  @Nullable
-  private ResolvedArtifact findArtifactForClassName(
-      final Map<ResolvedArtifact, Set<String>> artifactClassMap, final String className) {
-    for (Map.Entry<ResolvedArtifact, Set<String>> entry : artifactClassMap.entrySet()) {
-      if (entry.getValue().contains(className)) {
-        return entry.getKey();
-      }
-    }
-    return null;
   }
 
   /**
@@ -354,50 +344,37 @@ public class DefaultGradleProjectDependencyAnalyzer implements GradleProjectDepe
   }
 
   /**
-   * Computes a map of [dependency] -> [allTypes, usedTypes].
+   * Computes a map of [dependency] -> [allTypes, usedTypes]. The result is computed once per
+   * analysis; callers may invoke this method freely.
    *
    * @return A map of [dependency] -> [allTypes, usedTypes]
    */
   public Map<String, DependencyTypes> getDependenciesClassesMap() {
+    if (dependenciesClassesMap == null) {
+      dependenciesClassesMap = buildDependenciesClassesMap();
+    }
+    return dependenciesClassesMap;
+  }
+
+  private Map<String, DependencyTypes> buildDependenciesClassesMap() {
     // the output
     Map<String, DependencyTypes> dependenciesClassMap = new HashMap<>();
     // iterate through all the resolved artifacts
     for (Map.Entry<ResolvedArtifact, Set<String>> entry : artifactClassesMap.entrySet()) {
       ResolvedArtifact resolvedArtifact = entry.getKey();
       // all the types in all artifacts
-      Set<String> typesSet = artifactClassesMap.get(resolvedArtifact);
-      if (typesSet == null) {
-        typesSet = new HashSet<>();
-      }
       Set<ClassName> allClassNameSet = new HashSet<>();
-      for (String type : typesSet) {
+      for (String type : entry.getValue()) {
         allClassNameSet.add(new ClassName(type));
       }
       // all the types in used artifacts
-      Set<String> usedTypesSet = artifactUsedClassesMap.get(resolvedArtifact);
-      if (usedTypesSet == null) {
-        usedTypesSet = new HashSet<>();
-      }
       Set<ClassName> usedClassNameSet = new HashSet<>();
-      for (String type : usedTypesSet) {
+      for (String type : artifactUsedClassesMap.getOrDefault(resolvedArtifact, new HashSet<>())) {
         usedClassNameSet.add(new ClassName(type));
       }
-
-      if (artifactUsedClassesMap.containsKey(resolvedArtifact)) {
-        dependenciesClassMap.put(
-            resolvedArtifact.getModuleVersion().toString(),
-            new DependencyTypes(
-                allClassNameSet, // get all the typesSet
-                usedClassNameSet // get used typesSet
-                ));
-      } else {
-        dependenciesClassMap.put(
-            resolvedArtifact.getModuleVersion().toString(),
-            new DependencyTypes(
-                allClassNameSet, // get all the typesSet
-                new HashSet<>() // get used typesSet
-                ));
-      }
+      dependenciesClassMap.put(
+          resolvedArtifact.getModuleVersion().toString(),
+          new DependencyTypes(allClassNameSet, usedClassNameSet));
     }
     return dependenciesClassMap;
   }

--- a/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/json/JsonResultWriter.java
+++ b/depclean-gradle-plugin/src/main/java/se/kth/depclean/utils/json/JsonResultWriter.java
@@ -7,14 +7,22 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.io.FileUtils;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import se.kth.depclean.analysis.DefaultGradleProjectDependencyAnalyzer;
+import se.kth.depclean.core.analysis.DependencyTypes;
 import se.kth.depclean.core.analysis.graph.DefaultCallGraph;
 import se.kth.depclean.core.model.ClassName;
 
@@ -28,7 +36,6 @@ public class JsonResultWriter {
   private final Project project;
   private final Set<ResolvedDependency> allDependencies;
   private final Map<String, Long> sizeOfDependencies;
-  private final DefaultGradleProjectDependencyAnalyzer dependencyAnalyzer;
   private final Set<String> usedDirectArtifactsCoordinates;
   private final Set<String> usedInheritedArtifactsCoordinates;
   private final Set<String> usedTransitiveArtifactsCoordinates;
@@ -37,6 +44,10 @@ public class JsonResultWriter {
   private final Set<String> unusedTransitiveArtifactsCoordinates;
   private final File classUsageFile;
   private final boolean createClassUsageCsv;
+  private final Map<String, DependencyTypes> dependenciesClassesMap;
+  private final Set<String> classUsageDependenciesWritten = new HashSet<>();
+  @Nullable private Writer classUsageWriter;
+  @Nullable private Map<String, Set<String>> originsByTarget;
 
   /** Ctor. */
   public JsonResultWriter(
@@ -55,7 +66,6 @@ public class JsonResultWriter {
     this.project = project;
     this.classUsageFile = classUsageFile;
     this.allDependencies = declaredDependencies;
-    this.dependencyAnalyzer = dependencyAnalyzer;
     this.sizeOfDependencies = sizeOfDependencies;
     this.createClassUsageCsv = createClassUsageCsv;
     this.usedDirectArtifactsCoordinates = usedDirectArtifactsCoordinates;
@@ -64,6 +74,7 @@ public class JsonResultWriter {
     this.unusedDirectArtifactsCoordinates = unusedDirectArtifactsCoordinates;
     this.unusedInheritedArtifactsCoordinates = unusedInheritedArtifactsCoordinates;
     this.unusedTransitiveArtifactsCoordinates = unusedTransitiveArtifactsCoordinates;
+    this.dependenciesClassesMap = dependencyAnalyzer.getDependenciesClassesMap();
   }
 
   /**
@@ -73,6 +84,23 @@ public class JsonResultWriter {
    * @throws IOException If the JSON file cannot be written.
    */
   public void write(FileWriter fw) throws IOException {
+    // Appends below the header that DepCleanGradleAction writes when it (re)creates the file.
+    try (Writer csv =
+        createClassUsageCsv
+            ? Files.newBufferedWriter(
+                classUsageFile.toPath(),
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND)
+            : null) {
+      classUsageWriter = csv;
+      writeTree(fw);
+    } finally {
+      classUsageWriter = null;
+    }
+  }
+
+  private void writeTree(FileWriter fw) throws IOException {
 
     BufferedWriter bw = new BufferedWriter(fw, 512000);
     JsonWriter jsonWriter = new JsonWriter(bw);
@@ -85,9 +113,7 @@ public class JsonResultWriter {
     String projectCoordinates = projectId + ":" + null;
     String projectJar = projectArtifactId + "-" + projectVersion + ".jar";
 
-    if (createClassUsageCsv) {
-      writeClassUsageCsv(projectId);
-    }
+    writeClassUsageCsv(projectId);
 
     jsonWriter.setIndent("  ");
     JsonWriter localWriter =
@@ -132,9 +158,7 @@ public class JsonResultWriter {
       String version = dependency.getModuleVersion();
       String dependencyJar = artifactId + "-" + version + ".jar";
 
-      if (createClassUsageCsv) {
-        writeClassUsageCsv(dependencyId);
-      }
+      writeClassUsageCsv(dependencyId);
 
       JsonWriter childWriter =
           jsonWriter
@@ -209,38 +233,24 @@ public class JsonResultWriter {
   }
 
   private void writeUsageRatio(String dependencyId, JsonWriter localWriter) throws IOException {
+    DependencyTypes types = dependenciesClassesMap.get(dependencyId);
     localWriter
         .name("usageRatio")
         .value(
-            dependencyAnalyzer.getDependenciesClassesMap().containsKey(dependencyId)
-                ? dependencyAnalyzer
-                        .getDependenciesClassesMap()
-                        .get(dependencyId)
-                        .getAllTypes()
-                        .isEmpty()
-                    ? 0
-                    : // handle division by zero
-                    ((double)
-                            dependencyAnalyzer
-                                .getDependenciesClassesMap()
-                                .get(dependencyId)
-                                .getUsedTypes()
-                                .size()
-                        / dependencyAnalyzer
-                            .getDependenciesClassesMap()
-                            .get(dependencyId)
-                            .getAllTypes()
-                            .size())
-                : -1)
+            types == null
+                ? -1
+                : types.getAllTypes().isEmpty()
+                    ? 0 // handle division by zero
+                    : ((double) types.getUsedTypes().size() / types.getAllTypes().size()))
         .name("children(s)")
         .beginArray();
   }
 
   private void writeUsedTypes(String dependencyId, JsonWriter localWriter) throws IOException {
     JsonWriter usedTypes = localWriter.name("usedTypes").beginArray();
-    if (dependencyAnalyzer.getDependenciesClassesMap().containsKey(dependencyId)) {
-      for (ClassName usedType :
-          dependencyAnalyzer.getDependenciesClassesMap().get(dependencyId).getUsedTypes()) {
+    DependencyTypes types = dependenciesClassesMap.get(dependencyId);
+    if (types != null) {
+      for (ClassName usedType : types.getUsedTypes()) {
         usedTypes.value(usedType.getValue());
       }
     }
@@ -249,31 +259,53 @@ public class JsonResultWriter {
 
   private void writeAllTypes(String dependencyId, JsonWriter localWriter) throws IOException {
     JsonWriter allTypes = localWriter.name("allTypes").beginArray();
-    if (dependencyAnalyzer.getDependenciesClassesMap().containsKey(dependencyId)) {
-      for (ClassName allType :
-          dependencyAnalyzer.getDependenciesClassesMap().get(dependencyId).getAllTypes()) {
+    DependencyTypes types = dependenciesClassesMap.get(dependencyId);
+    if (types != null) {
+      for (ClassName allType : types.getAllTypes()) {
         allTypes.value(allType.getValue());
       }
     }
     allTypes.endArray();
   }
 
+  /**
+   * Writes one {@code caller,callee,dependency} line per call-graph edge whose target class belongs
+   * to the given dependency, sorted by caller then callee. Each dependency is written once even if
+   * it appears several times in the dependency tree.
+   */
   private void writeClassUsageCsv(String dependencyId) throws IOException {
-    for (Map.Entry<String, Set<String>> usagePerClassMap :
-        DefaultCallGraph.getUsagesPerClass().entrySet()) {
-      String key = usagePerClassMap.getKey();
-      Set<String> value = usagePerClassMap.getValue();
-      for (String s : value) {
-        if (dependencyAnalyzer.getDependenciesClassesMap().containsKey(dependencyId)
-            && dependencyAnalyzer
-                .getDependenciesClassesMap()
-                .get(dependencyId)
-                .getAllTypes()
-                .contains(new ClassName(s))) {
-          String triplet = key + "," + s + "," + dependencyId + "\n";
-          FileUtils.write(classUsageFile, triplet, StandardCharsets.UTF_8, true);
-        }
+    DependencyTypes types = dependenciesClassesMap.get(dependencyId);
+    if (classUsageWriter == null
+        || types == null
+        || !classUsageDependenciesWritten.add(dependencyId)) {
+      return;
+    }
+    Map<String, Set<String>> originsByTarget = originsByTarget();
+    Map<String, Set<String>> targetsByOrigin = new TreeMap<>();
+    for (ClassName type : types.getAllTypes()) {
+      for (String origin : originsByTarget.getOrDefault(type.getValue(), new HashSet<>())) {
+        targetsByOrigin.computeIfAbsent(origin, k -> new TreeSet<>()).add(type.getValue());
       }
     }
+    for (Map.Entry<String, Set<String>> edges : targetsByOrigin.entrySet()) {
+      for (String target : edges.getValue()) {
+        classUsageWriter.write(edges.getKey() + "," + target + "," + dependencyId + "\n");
+      }
+    }
+  }
+
+  /** The call graph inverted (target class to its callers), built once per JSON write. */
+  private Map<String, Set<String>> originsByTarget() {
+    if (originsByTarget == null) {
+      Map<String, Set<String>> inverted = new HashMap<>();
+      for (Map.Entry<String, Set<String>> usages :
+          DefaultCallGraph.getUsagesPerClass().entrySet()) {
+        for (String target : usages.getValue()) {
+          inverted.computeIfAbsent(target, k -> new HashSet<>()).add(usages.getKey());
+        }
+      }
+      originsByTarget = inverted;
+    }
+    return originsByTarget;
   }
 }

--- a/depclean-gradle-plugin/src/test/groovy/se/kth/depclean/DepCleanGradleFT.groovy
+++ b/depclean-gradle-plugin/src/test/groovy/se/kth/depclean/DepCleanGradleFT.groovy
@@ -98,6 +98,7 @@ class DepCleanGradleFT extends Specification {
     String projectPath4 = "src/test/resources-fts/json_should_be_correct"
     File json_should_be_correct = new File(projectPath4)
     File generatedResultDotJson = new File(projectPath4 + "/build/depclean-results.json");
+    File generatedClassUsageCsv = new File(projectPath4 + "/build/class-usage.csv");
 
     def "Test that the depclean creates a proper results.json file"() {
         given:
@@ -113,6 +114,19 @@ class DepCleanGradleFT extends Specification {
         assert checkTaskOutcome(debloatResult.task(":debloat").getOutcome())
 
         assert generatedResultDotJson.exists()
+
+        and: "the class-usage CSV lists each edge once, under the dependency owning its target"
+        List<String> lines = generatedClassUsageCsv.readLines()
+        assert lines[0] == "OriginClass,TargetClass,Dependency"
+        List<String> edges = lines.drop(1)
+        assert !edges.isEmpty()
+        assert edges.every { it.split(",").length == 3 }
+        assert edges.size() == edges.toSet().size()
+        // JDK classes belong to no dependency, so they never appear as targets
+        assert edges.every { !it.split(",")[1].startsWith("java.") }
+        // the project's own class references commons-codec, which must be attributed to it
+        // (the origin may or may not carry its package prefix, see ClassFileVisitorUtils.getChild)
+        assert edges.any { it ==~ /(org\.)?UseCommonsCodec,org\.apache\.commons\.codec\.Charsets,commons-codec:commons-codec:1\.22\.1/ }
     }
 
     String projectPath5 = "src/test/resources-fts/multi_project"

--- a/depclean-gradle-plugin/src/test/resources-fts/json_should_be_correct/build.gradle
+++ b/depclean-gradle-plugin/src/test/resources-fts/json_should_be_correct/build.gradle
@@ -40,4 +40,5 @@ tasks.withType(JavaCompile).configureEach {
 
 depclean {
     createResultJson = true
+    createClassUsageCsv = true
 }


### PR DESCRIPTION
## Summary

Gradle-plugin counterpart of #541 / #542: profile the `debloat` task on spring-petclinic with async-profiler (wall clock) and fix what showed up. The analysis-only path already benefited from #541 through depclean-core; the problems here are Gradle-plugin-only code.

## Findings

Baseline on spring-petclinic (`main`, Gradle build, ~150 artifacts, 52k dependency classes):

| scenario | before | after |
|---|---|---|
| `debloat` (analysis only) | 26s | 23s |
| `debloat` + `createResultJson` + `createClassUsageCsv` | **never finished** (killed after several minutes; CSV still at 1 line) | **31s** |

Thread dump of the stuck run: `JsonResultWriter.writeClassUsageCsv → DefaultGradleProjectDependencyAnalyzer.getDependenciesClassesMap → HashSet.add`.

1. **`getDependenciesClassesMap()` recomputed the entire map on every call** — one `ClassName` per class across all artifacts. `JsonResultWriter` called it several times per tree node and **twice per call-graph edge** inside `writeClassUsageCsv`, i.e. O(nodes × edges × classes).
2. **`collectUsedArtifacts`** did a linear scan over every artifact's class set for every referenced class, and called `findArtifactForClassName` twice per class.
3. `writeClassUsageCsv` appended one line per `FileUtils.write(append)` call and repeated a dependency's edges every time it reappeared in the tree.

## Changes

- `DefaultGradleProjectDependencyAnalyzer`: memoize `getDependenciesClassesMap()` per analysis (reset when `analyze` runs); invert the artifact→classes map once and look classes up by hash in `collectUsedArtifacts` (first artifact declaring a class still wins, as before).
- `JsonResultWriter`: resolve the types map once; write the CSV through a single buffered writer opened for the whole JSON traversal (appending below the header the action writes); write each dependency once; take edges from a target→callers index built once; sort by origin then target for deterministic output.
- `DepCleanGradleFT` / `json_should_be_correct`: the fixture now enables `createClassUsageCsv`; the spec asserts header, three columns, no duplicate lines, no JDK classes as targets, and that the project's `UseCommonsCodec → org.apache.commons.codec.Charsets` edge is attributed to `commons-codec:commons-codec:1.22.1`.

For comparison, the Maven plugin on the same project with the same flags takes 72s; its `NodeAdapter` still re-sorts the whole edge map per tree node and will get the same index in a follow-up.

## Verification

- `./gradlew clean publishToMavenLocal build` green (spotless, ErrorProne/NullAway, unit + functional tests).
- petclinic CSV after the change: 409,574 lines, 149 dependencies, 0 duplicate lines, 0 `java.*` targets.

## Also observed (not in this PR)

The `ZIP bomb detected: too many entries` warning printed during these runs is a core false positive on `testcontainers-2.0.5.jar` (12.5k entries) — addressed separately.
