### PR TITLE
feat(maven-plugin): add depclean:report goal for the Maven Site (#478)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,11 +128,15 @@ jobs:
           "$MVN" -version
           "$MVN" -ntp -f .github/smoke/java8/pom.xml \
             package se.kth.castor:depclean-maven-plugin:${{ steps.version.outputs.version }}:depclean \
+            se.kth.castor:depclean-maven-plugin:${{ steps.version.outputs.version }}:report \
             | tee /tmp/depclean-smoke.log
           # Maven 4 prefixes the plugin's stdout with "[INFO] [stdout] ", hence substring matches
           grep 'D E P C L E A N   A N A L Y S I S   R E S U L T S' /tmp/depclean-smoke.log
           grep -A2 'USED DIRECT DEPENDENCIES \[1\]' /tmp/depclean-smoke.log | grep 'commons-io:commons-io'
           grep -A2 'POTENTIALLY UNUSED DIRECT DEPENDENCIES \[1\]' /tmp/depclean-smoke.log | grep 'org.apache.commons:commons-lang3'
+          # The site report must reuse the analysis of the depclean goal and render it (Doxia 2 stack on this JDK)
+          grep 'Reusing the DepClean analysis from' /tmp/depclean-smoke.log
+          grep -q '<td>commons-lang3</td>' .github/smoke/java8/target/reports/depclean.html
 
   # --------------------------------------------------------------------------------------------------------------------
   # The Gradle plugin, its test fixtures and the READMEs carry the version as a literal;

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [What is DepClean?](#what-is-depclean)
 - [Usage](#usage)
 - [Optional Parameters](#optional-parameters)
+- [Maven Site report](#maven-site-report)
 - [How does DepClean work?](#how-does-depclean-work)
 - [Gradle Plugin](#gradle-plugin)
 - [Installing and building from source](#installing-and-building-from-source)
@@ -92,7 +93,7 @@ Let's see an example of running DepClean in the project [Apache Commons Numbers]
 
 ## Optional Parameters
 
-The Maven plugin can be configured with the following additional parameters.
+The Maven plugin can be configured with the following additional parameters. `ignoreDependencies`, `ignoreScopes`, `ignoreTests` and `skipDepClean` also apply to the [`report` goal](#maven-site-report).
 
 | Name                       |     Type      | Description                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | :------------------------- | :-----------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -136,6 +137,41 @@ Of course, it is also possible to execute DepClean with parameters directly from
 ```bash
 mvn se.kth.castor:depclean-maven-plugin:2.2.0:depclean -DfailIfUnusedDirect=true -DignoreScopes=provided,test,runtime,system,import
 ```
+
+Every `depclean` run also leaves a machine-readable summary of the analysis in `target/depclean-analysis.json`; the `report` goal reuses it to avoid analysing the project twice.
+
+## Maven Site report
+
+The `report` goal renders the analysis as a page of the Maven site (`target/site/depclean.html`), listed in the "Project Reports" section. It shows a summary per category (used and potentially unused × direct, transitive, inherited direct, inherited transitive, plus the dependencies ignored by configuration), a table per category with coordinates, scope and size, and the classes the project uses from each used dependency. The report is read-only: it never writes `pom-debloated.xml` or fails the build.
+
+```xml
+<reporting>
+  <plugins>
+    <plugin>
+      <groupId>se.kth.castor</groupId>
+      <artifactId>depclean-maven-plugin</artifactId>
+      <version>2.2.0</version>
+      <reportSets>
+        <reportSet>
+          <reports>
+            <report>report</report>
+          </reports>
+        </reportSet>
+      </reportSets>
+    </plugin>
+  </plugins>
+</reporting>
+```
+
+Then run `mvn site`. The goal forks `test-compile`, so the project does not need to be built first. If `depclean:depclean` already ran in the same build (for example `mvn verify site`) and neither the POM nor the compiled classes changed since, its result is reused instead of running the analysis again.
+
+The report can also be generated on its own, in which case it is written to `target/reports/depclean.html`:
+
+```bash
+mvn se.kth.castor:depclean-maven-plugin:2.2.0:report
+```
+
+The report is built on Doxia 2 and therefore needs `maven-site-plugin` 3.20.0 or newer. Maven 3.9 still defaults to 3.12.1, so pin a recent version in `<build><pluginManagement>`; Maven 4 defaults to a compatible version.
 
 ## How does DepClean work?
 

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -22,12 +22,15 @@
 
   <properties>
     <!-- Dependencies -->
+    <doxia.version>2.0.0</doxia.version>
     <gson.version>2.14.0</gson.version>
     <itf-jupiter-extension.version>0.13.1</itf-jupiter-extension.version>
     <javax.inject.version>1</javax.inject.version>
     <maven-dependency-tree-parser.version>1.0.6</maven-dependency-tree-parser.version>
     <maven-dependency-tree.version>3.3.0</maven-dependency-tree.version>
     <maven-plugin-annotations.version>3.15.2</maven-plugin-annotations.version>
+    <maven-reporting-api.version>4.0.0</maven-reporting-api.version>
+    <maven-reporting-impl.version>4.0.0</maven-reporting-impl.version>
     <plexus-xml.version>4.2.0</plexus-xml.version>
 
     <!-- Plugins -->
@@ -90,6 +93,30 @@
       <artifactId>plexus-xml</artifactId>
       <version>${plexus-xml.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <!-- Maven Site report (depclean:report) -->
+    <dependency>
+      <groupId>org.apache.maven.reporting</groupId>
+      <artifactId>maven-reporting-api</artifactId>
+      <version>${maven-reporting-api.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.reporting</groupId>
+      <artifactId>maven-reporting-impl</artifactId>
+      <version>${maven-reporting-impl.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.doxia</groupId>
+      <artifactId>doxia-sink-api</artifactId>
+      <version>${doxia.version}</version>
+    </dependency>
+    <!-- Renders the report sink to XHTML in unit tests -->
+    <dependency>
+      <groupId>org.apache.maven.doxia</groupId>
+      <artifactId>doxia-module-xhtml5</artifactId>
+      <version>${doxia.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- Utils -->

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
@@ -18,6 +18,7 @@
 package se.kth.depclean;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Set;
 import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
@@ -31,6 +32,9 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import se.kth.depclean.core.DepCleanManager;
 import se.kth.depclean.core.analysis.AnalysisFailureException;
+import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
+import se.kth.depclean.report.AnalysisSnapshot;
+import se.kth.depclean.report.AnalysisSnapshotFile;
 import se.kth.depclean.wrapper.MavenDependencyManager;
 
 /**
@@ -152,22 +156,36 @@ public class DepCleanMojo extends AbstractMojo {
   @Override
   public final void execute() throws MojoExecutionException {
     try {
-      new DepCleanManager(
-              new MavenDependencyManager(getLog(), project, session, dependencyGraphBuilder),
-              skipDepClean,
-              ignoreTests,
-              ignoreScopes,
-              ignoreDependencies,
-              failIfUnusedDirect,
-              failIfUnusedTransitive,
-              failIfUnusedInheritedDirect,
-              failIfUnusedInheritedTransitive,
-              createPomDebloated,
-              createResultJson,
-              createCallGraphCsv)
-          .execute();
+      ProjectDependencyAnalysis analysis =
+          new DepCleanManager(
+                  new MavenDependencyManager(getLog(), project, session, dependencyGraphBuilder),
+                  skipDepClean,
+                  ignoreTests,
+                  ignoreScopes,
+                  ignoreDependencies,
+                  failIfUnusedDirect,
+                  failIfUnusedTransitive,
+                  failIfUnusedInheritedDirect,
+                  failIfUnusedInheritedTransitive,
+                  createPomDebloated,
+                  createResultJson,
+                  createCallGraphCsv)
+              .execute();
+      if (analysis != null) {
+        writeSnapshot(analysis);
+      }
     } catch (AnalysisFailureException | IOException e) {
       throw new MojoExecutionException(e.getMessage(), e);
     }
+  }
+
+  /** Persists the result so that {@code depclean:report} can reuse it instead of re-analyzing. */
+  private void writeSnapshot(ProjectDependencyAnalysis analysis) throws IOException {
+    AnalysisSnapshotFile snapshotFile =
+        new AnalysisSnapshotFile(Paths.get(project.getBuild().getDirectory()));
+    snapshotFile.write(
+        AnalysisSnapshot.from(
+            analysis, new AnalysisSnapshot.Settings(ignoreTests, ignoreScopes, ignoreDependencies)));
+    getLog().info("Analysis snapshot written to " + snapshotFile.getPath());
   }
 }

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
@@ -19,6 +19,7 @@ package se.kth.depclean;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Set;
 import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
@@ -33,6 +34,7 @@ import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import se.kth.depclean.core.DepCleanManager;
 import se.kth.depclean.core.analysis.AnalysisFailureException;
 import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
+import se.kth.depclean.report.AnalysisInputs;
 import se.kth.depclean.report.AnalysisSnapshot;
 import se.kth.depclean.report.AnalysisSnapshotFile;
 import se.kth.depclean.wrapper.MavenDependencyManager;
@@ -183,9 +185,17 @@ public class DepCleanMojo extends AbstractMojo {
   private void writeSnapshot(ProjectDependencyAnalysis analysis) throws IOException {
     AnalysisSnapshotFile snapshotFile =
         new AnalysisSnapshotFile(Paths.get(project.getBuild().getDirectory()));
+    String inputsFingerprint =
+        AnalysisInputs.fingerprint(
+            project.getFile().toPath(),
+            Arrays.asList(
+                Paths.get(project.getBuild().getOutputDirectory()),
+                Paths.get(project.getBuild().getTestOutputDirectory())));
     snapshotFile.write(
         AnalysisSnapshot.from(
-            analysis, new AnalysisSnapshot.Settings(ignoreTests, ignoreScopes, ignoreDependencies)));
+            analysis,
+            new AnalysisSnapshot.Settings(ignoreTests, ignoreScopes, ignoreDependencies),
+            inputsFingerprint));
     getLog().info("Analysis snapshot written to " + snapshotFile.getPath());
   }
 }

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
@@ -19,7 +19,6 @@ package se.kth.depclean;
 
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Set;
 import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
@@ -188,9 +187,10 @@ public class DepCleanMojo extends AbstractMojo {
     String inputsFingerprint =
         AnalysisInputs.fingerprint(
             project.getFile().toPath(),
-            Arrays.asList(
+            AnalysisInputs.classDirectories(
                 Paths.get(project.getBuild().getOutputDirectory()),
-                Paths.get(project.getBuild().getTestOutputDirectory())));
+                Paths.get(project.getBuild().getTestOutputDirectory()),
+                ignoreTests));
     snapshotFile.write(
         AnalysisSnapshot.from(
             analysis,

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanReportMojo.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanReportMojo.java
@@ -38,6 +38,7 @@ import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import se.kth.depclean.core.DepCleanManager;
 import se.kth.depclean.core.analysis.AnalysisFailureException;
 import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
+import se.kth.depclean.report.AnalysisInputs;
 import se.kth.depclean.report.AnalysisSnapshot;
 import se.kth.depclean.report.AnalysisSnapshotFile;
 import se.kth.depclean.report.DepCleanReportRenderer;
@@ -127,14 +128,15 @@ public class DepCleanReportMojo extends AbstractMavenReport {
     AnalysisSnapshotFile snapshotFile =
         new AnalysisSnapshotFile(Paths.get(project.getBuild().getDirectory()));
     try {
-      Optional<AnalysisSnapshot> stored =
-          snapshotFile.readIfFresh(settings, project.getFile().toPath(), classDirectories());
+      String inputsFingerprint =
+          AnalysisInputs.fingerprint(project.getFile().toPath(), classDirectories());
+      Optional<AnalysisSnapshot> stored = snapshotFile.readIfFresh(settings, inputsFingerprint);
       AnalysisSnapshot snapshot;
       if (stored.isPresent()) {
         getLog().info("Reusing the DepClean analysis from " + snapshotFile.getPath());
         snapshot = stored.get();
       } else {
-        snapshot = analyze(settings);
+        snapshot = analyze(settings, inputsFingerprint);
         snapshotFile.write(snapshot);
       }
       new DepCleanReportRenderer(getSink(), snapshot, project.getName(), stored.isPresent())
@@ -144,7 +146,7 @@ public class DepCleanReportMojo extends AbstractMavenReport {
     }
   }
 
-  private AnalysisSnapshot analyze(AnalysisSnapshot.Settings settings)
+  private AnalysisSnapshot analyze(AnalysisSnapshot.Settings settings, String inputsFingerprint)
       throws AnalysisFailureException, IOException, MavenReportException {
     ProjectDependencyAnalysis analysis =
         new DepCleanManager(
@@ -164,7 +166,7 @@ public class DepCleanReportMojo extends AbstractMavenReport {
     if (analysis == null) {
       throw new MavenReportException("DepClean did not analyse the project");
     }
-    return AnalysisSnapshot.from(analysis, settings);
+    return AnalysisSnapshot.from(analysis, settings, inputsFingerprint);
   }
 
   private List<Path> classDirectories() {

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanReportMojo.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanReportMojo.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2020, CASTOR Software Research Centre (www.castor.kth.se)
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package se.kth.depclean;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.reporting.AbstractMavenReport;
+import org.apache.maven.reporting.MavenReportException;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import se.kth.depclean.core.DepCleanManager;
+import se.kth.depclean.core.analysis.AnalysisFailureException;
+import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
+import se.kth.depclean.report.AnalysisSnapshot;
+import se.kth.depclean.report.AnalysisSnapshotFile;
+import se.kth.depclean.report.DepCleanReportRenderer;
+import se.kth.depclean.wrapper.MavenDependencyManager;
+
+/**
+ * Generates the DepClean page of the Maven site ({@code target/site/depclean.html}), listing the
+ * used and potentially unused dependencies of the project. The report is read-only: it never
+ * rewrites the POM nor fails the build. When {@code depclean:depclean} already ran in the same
+ * build, its result is reused instead of analysing the project a second time.
+ */
+@Mojo(
+    name = "report",
+    requiresDependencyCollection = ResolutionScope.TEST,
+    requiresDependencyResolution = ResolutionScope.TEST,
+    threadSafe = true)
+@Execute(phase = LifecyclePhase.TEST_COMPILE)
+public class DepCleanReportMojo extends AbstractMavenReport {
+
+  /** The Maven session. */
+  @Parameter(defaultValue = "${session}", readonly = true)
+  @SuppressWarnings("NullAway") // Injected by Maven
+  private MavenSession session;
+
+  /**
+   * Add a list of regular expressions matching dependencies to be ignored by DepClean during the
+   * analysis and considered as used dependencies. Each pattern is matched (case-insensitively)
+   * against the whole <code>groupId:artifactId:version:scope</code> coordinate.
+   */
+  @Parameter(property = "ignoreDependencies")
+  @SuppressWarnings("NullAway") // Injected by Maven
+  private Set<String> ignoreDependencies;
+
+  /** Ignore dependencies with specific scopes from the DepClean analysis. */
+  @Parameter(property = "ignoreScopes")
+  @SuppressWarnings("NullAway") // Injected by Maven
+  private Set<String> ignoreScopes;
+
+  /**
+   * If this is true, DepClean will not analyze the test sources in the project, and, therefore, the
+   * dependencies that are only used for testing will be considered unused.
+   */
+  @Parameter(property = "ignoreTests", defaultValue = "false")
+  private boolean ignoreTests;
+
+  /** Skip the report completely. */
+  @Parameter(property = "skipDepClean", defaultValue = "false")
+  private boolean skipDepClean;
+
+  /** To build the dependency graph. */
+  @Inject
+  @SuppressWarnings("NullAway") // Injected by Maven
+  private DependencyGraphBuilder dependencyGraphBuilder;
+
+  @Override
+  public String getOutputName() {
+    return "depclean";
+  }
+
+  @Override
+  public String getName(Locale locale) {
+    return "DepClean";
+  }
+
+  @Override
+  public String getDescription(Locale locale) {
+    return "Used and potentially unused dependencies detected by DepClean's bytecode analysis.";
+  }
+
+  @Override
+  public boolean canGenerateReport() throws MavenReportException {
+    if (skipDepClean) {
+      getLog().info("Skipping DepClean report");
+      return false;
+    }
+    if ("pom".equals(project.getPackaging())) {
+      getLog().info("Skipping DepClean report because packaging type is pom");
+      return false;
+    }
+    return super.canGenerateReport();
+  }
+
+  @Override
+  protected void executeReport(Locale locale) throws MavenReportException {
+    AnalysisSnapshot.Settings settings =
+        new AnalysisSnapshot.Settings(ignoreTests, ignoreScopes, ignoreDependencies);
+    AnalysisSnapshotFile snapshotFile =
+        new AnalysisSnapshotFile(Paths.get(project.getBuild().getDirectory()));
+    try {
+      Optional<AnalysisSnapshot> stored =
+          snapshotFile.readIfFresh(settings, project.getFile().toPath(), classDirectories());
+      AnalysisSnapshot snapshot;
+      if (stored.isPresent()) {
+        getLog().info("Reusing the DepClean analysis from " + snapshotFile.getPath());
+        snapshot = stored.get();
+      } else {
+        snapshot = analyze(settings);
+        snapshotFile.write(snapshot);
+      }
+      new DepCleanReportRenderer(getSink(), snapshot, project.getName(), stored.isPresent())
+          .render();
+    } catch (AnalysisFailureException | IOException e) {
+      throw new MavenReportException("Unable to generate the DepClean report", e);
+    }
+  }
+
+  private AnalysisSnapshot analyze(AnalysisSnapshot.Settings settings)
+      throws AnalysisFailureException, IOException, MavenReportException {
+    ProjectDependencyAnalysis analysis =
+        new DepCleanManager(
+                new MavenDependencyManager(getLog(), project, session, dependencyGraphBuilder),
+                false,
+                ignoreTests,
+                ignoreScopes,
+                ignoreDependencies,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false)
+            .execute();
+    if (analysis == null) {
+      throw new MavenReportException("DepClean did not analyse the project");
+    }
+    return AnalysisSnapshot.from(analysis, settings);
+  }
+
+  private List<Path> classDirectories() {
+    return Arrays.asList(
+        Paths.get(project.getBuild().getOutputDirectory()),
+        Paths.get(project.getBuild().getTestOutputDirectory()));
+  }
+}

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanReportMojo.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanReportMojo.java
@@ -20,7 +20,6 @@ package se.kth.depclean;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -170,8 +169,9 @@ public class DepCleanReportMojo extends AbstractMavenReport {
   }
 
   private List<Path> classDirectories() {
-    return Arrays.asList(
+    return AnalysisInputs.classDirectories(
         Paths.get(project.getBuild().getOutputDirectory()),
-        Paths.get(project.getBuild().getTestOutputDirectory()));
+        Paths.get(project.getBuild().getTestOutputDirectory()),
+        ignoreTests);
   }
 }

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisInputs.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisInputs.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020, CASTOR Software Research Centre (www.castor.kth.se)
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package se.kth.depclean.report;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Fingerprints what a DepClean analysis is computed from: the POM and the compiled class files. Two
+ * runs over identical inputs yield the same fingerprint, so a stored snapshot can be trusted
+ * whenever the fingerprint still matches, even if the class files were recompiled in between (a
+ * forked lifecycle does that on some platforms) and therefore carry newer timestamps.
+ */
+public final class AnalysisInputs {
+
+  private AnalysisInputs() {}
+
+  /**
+   * Computes the SHA-256 fingerprint of the POM and of every {@code .class} file under the given
+   * directories. Missing directories contribute nothing.
+   *
+   * @param pom the project POM
+   * @param classDirectories the compiled main and test class directories
+   * @return a lowercase hexadecimal digest
+   */
+  public static String fingerprint(Path pom, Collection<Path> classDirectories) throws IOException {
+    MessageDigest digest = sha256();
+    digest.update(Files.readAllBytes(pom));
+    for (Path directory : classDirectories) {
+      if (!Files.isDirectory(directory)) {
+        continue;
+      }
+      for (Path file : classFiles(directory)) {
+        // The relative path makes renames and moves visible, not just content changes
+        digest.update(directory.relativize(file).toString().getBytes(StandardCharsets.UTF_8));
+        digest.update((byte) 0);
+        digest.update(Files.readAllBytes(file));
+      }
+    }
+    return hex(digest.digest());
+  }
+
+  private static List<Path> classFiles(Path directory) throws IOException {
+    try (Stream<Path> files = Files.walk(directory)) {
+      return files
+          .filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().endsWith(".class"))
+          .sorted()
+          .collect(Collectors.toList());
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
+  }
+
+  private static MessageDigest sha256() {
+    try {
+      return MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is mandatory on every JVM", e);
+    }
+  }
+
+  private static String hex(byte[] bytes) {
+    StringBuilder builder = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      builder
+          .append(Character.forDigit((b >> 4) & 0xF, 16))
+          .append(Character.forDigit(b & 0xF, 16));
+    }
+    return builder.toString();
+  }
+}

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisInputs.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisInputs.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -38,6 +39,25 @@ import java.util.stream.Stream;
 public final class AnalysisInputs {
 
   private AnalysisInputs() {}
+
+  /**
+   * The class directories an analysis actually reads. Test classes are only an input when tests
+   * are analysed, so with {@code ignoreTests} they must not invalidate a stored snapshot either.
+   *
+   * @param classDirectory the compiled main class directory
+   * @param testClassDirectory the compiled test class directory
+   * @param ignoreTests whether the analysis skips the test classes
+   * @return the directories to fingerprint
+   */
+  public static List<Path> classDirectories(
+      Path classDirectory, Path testClassDirectory, boolean ignoreTests) {
+    List<Path> directories = new ArrayList<>();
+    directories.add(classDirectory);
+    if (!ignoreTests) {
+      directories.add(testClassDirectory);
+    }
+    return directories;
+  }
 
   /**
    * Computes the SHA-256 fingerprint of the POM and of every {@code .class} file under the given

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisSnapshot.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisSnapshot.java
@@ -40,6 +40,7 @@ import se.kth.depclean.core.model.Dependency;
 public final class AnalysisSnapshot {
 
   private final Settings settings;
+  private final String inputsFingerprint;
   private final List<Entry> usedDirect;
   private final List<Entry> usedTransitive;
   private final List<Entry> usedInheritedDirect;
@@ -50,9 +51,14 @@ public final class AnalysisSnapshot {
   private final List<Entry> unusedInheritedTransitive;
   private final List<Entry> ignored;
 
-  /** Creates a snapshot from already categorized entries. */
+  /**
+   * Creates a snapshot from already categorized entries.
+   *
+   * @param inputsFingerprint the {@link AnalysisInputs#fingerprint} of what was analysed
+   */
   public AnalysisSnapshot(
       Settings settings,
+      String inputsFingerprint,
       List<Entry> usedDirect,
       List<Entry> usedTransitive,
       List<Entry> usedInheritedDirect,
@@ -63,6 +69,7 @@ public final class AnalysisSnapshot {
       List<Entry> unusedInheritedTransitive,
       List<Entry> ignored) {
     this.settings = settings;
+    this.inputsFingerprint = inputsFingerprint;
     this.usedDirect = sorted(usedDirect);
     this.usedTransitive = sorted(usedTransitive);
     this.usedInheritedDirect = sorted(usedInheritedDirect);
@@ -74,10 +81,15 @@ public final class AnalysisSnapshot {
     this.ignored = sorted(ignored);
   }
 
-  /** Captures the result of an analysis together with the settings that produced it. */
-  public static AnalysisSnapshot from(ProjectDependencyAnalysis analysis, Settings settings) {
+  /**
+   * Captures the result of an analysis together with the settings and the fingerprint of the inputs
+   * that produced it.
+   */
+  public static AnalysisSnapshot from(
+      ProjectDependencyAnalysis analysis, Settings settings, String inputsFingerprint) {
     return new AnalysisSnapshot(
         settings,
+        inputsFingerprint,
         entries(analysis, analysis.getUsedDirectDependencies()),
         entries(analysis, analysis.getUsedTransitiveDependencies()),
         entries(analysis, analysis.getUsedInheritedDirectDependencies()),
@@ -92,7 +104,9 @@ public final class AnalysisSnapshot {
   private static List<Entry> entries(
       ProjectDependencyAnalysis analysis, Collection<Dependency> dependencies) {
     return dependencies.stream()
-        .map(dependency -> Entry.from(dependency, analysis.getDependencyClassesMap().get(dependency)))
+        .map(
+            dependency ->
+                Entry.from(dependency, analysis.getDependencyClassesMap().get(dependency)))
         .collect(Collectors.toList());
   }
 
@@ -104,6 +118,10 @@ public final class AnalysisSnapshot {
 
   public Settings getSettings() {
     return settings;
+  }
+
+  public String getInputsFingerprint() {
+    return inputsFingerprint;
   }
 
   public List<Entry> getUsedDirect() {
@@ -151,7 +169,9 @@ public final class AnalysisSnapshot {
 
     /** Creates the settings; both sets are copied into sorted sets. */
     public Settings(
-        boolean ignoreTests, Collection<String> ignoreScopes, Collection<String> ignoreDependencies) {
+        boolean ignoreTests,
+        Collection<String> ignoreScopes,
+        Collection<String> ignoreDependencies) {
       this.ignoreTests = ignoreTests;
       this.ignoreScopes = Collections.unmodifiableSet(new TreeSet<>(ignoreScopes));
       this.ignoreDependencies = Collections.unmodifiableSet(new TreeSet<>(ignoreDependencies));

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisSnapshot.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisSnapshot.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2020, CASTOR Software Research Centre (www.castor.kth.se)
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package se.kth.depclean.report;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
+import se.kth.depclean.core.analysis.DependencyTypes;
+import se.kth.depclean.core.analysis.model.ProjectDependencyAnalysis;
+import se.kth.depclean.core.model.ClassName;
+import se.kth.depclean.core.model.Dependency;
+
+/**
+ * Serializable snapshot of a {@link ProjectDependencyAnalysis}: what {@code depclean:depclean}
+ * hands over to {@code depclean:report} through {@code target/depclean-analysis.json}, so that the
+ * report does not have to run the analysis a second time.
+ */
+public final class AnalysisSnapshot {
+
+  private final Settings settings;
+  private final List<Entry> usedDirect;
+  private final List<Entry> usedTransitive;
+  private final List<Entry> usedInheritedDirect;
+  private final List<Entry> usedInheritedTransitive;
+  private final List<Entry> unusedDirect;
+  private final List<Entry> unusedTransitive;
+  private final List<Entry> unusedInheritedDirect;
+  private final List<Entry> unusedInheritedTransitive;
+  private final List<Entry> ignored;
+
+  /** Creates a snapshot from already categorized entries. */
+  public AnalysisSnapshot(
+      Settings settings,
+      List<Entry> usedDirect,
+      List<Entry> usedTransitive,
+      List<Entry> usedInheritedDirect,
+      List<Entry> usedInheritedTransitive,
+      List<Entry> unusedDirect,
+      List<Entry> unusedTransitive,
+      List<Entry> unusedInheritedDirect,
+      List<Entry> unusedInheritedTransitive,
+      List<Entry> ignored) {
+    this.settings = settings;
+    this.usedDirect = sorted(usedDirect);
+    this.usedTransitive = sorted(usedTransitive);
+    this.usedInheritedDirect = sorted(usedInheritedDirect);
+    this.usedInheritedTransitive = sorted(usedInheritedTransitive);
+    this.unusedDirect = sorted(unusedDirect);
+    this.unusedTransitive = sorted(unusedTransitive);
+    this.unusedInheritedDirect = sorted(unusedInheritedDirect);
+    this.unusedInheritedTransitive = sorted(unusedInheritedTransitive);
+    this.ignored = sorted(ignored);
+  }
+
+  /** Captures the result of an analysis together with the settings that produced it. */
+  public static AnalysisSnapshot from(ProjectDependencyAnalysis analysis, Settings settings) {
+    return new AnalysisSnapshot(
+        settings,
+        entries(analysis, analysis.getUsedDirectDependencies()),
+        entries(analysis, analysis.getUsedTransitiveDependencies()),
+        entries(analysis, analysis.getUsedInheritedDirectDependencies()),
+        entries(analysis, analysis.getUsedInheritedTransitiveDependencies()),
+        entries(analysis, analysis.getUnusedDirectDependencies()),
+        entries(analysis, analysis.getUnusedTransitiveDependencies()),
+        entries(analysis, analysis.getUnusedInheritedDirectDependencies()),
+        entries(analysis, analysis.getUnusedInheritedTransitiveDependencies()),
+        entries(analysis, analysis.getIgnoredDependencies()));
+  }
+
+  private static List<Entry> entries(
+      ProjectDependencyAnalysis analysis, Collection<Dependency> dependencies) {
+    return dependencies.stream()
+        .map(dependency -> Entry.from(dependency, analysis.getDependencyClassesMap().get(dependency)))
+        .collect(Collectors.toList());
+  }
+
+  private static List<Entry> sorted(List<Entry> entries) {
+    List<Entry> copy = new ArrayList<>(entries);
+    copy.sort(Comparator.comparing(Entry::coordinate));
+    return Collections.unmodifiableList(copy);
+  }
+
+  public Settings getSettings() {
+    return settings;
+  }
+
+  public List<Entry> getUsedDirect() {
+    return usedDirect;
+  }
+
+  public List<Entry> getUsedTransitive() {
+    return usedTransitive;
+  }
+
+  public List<Entry> getUsedInheritedDirect() {
+    return usedInheritedDirect;
+  }
+
+  public List<Entry> getUsedInheritedTransitive() {
+    return usedInheritedTransitive;
+  }
+
+  public List<Entry> getUnusedDirect() {
+    return unusedDirect;
+  }
+
+  public List<Entry> getUnusedTransitive() {
+    return unusedTransitive;
+  }
+
+  public List<Entry> getUnusedInheritedDirect() {
+    return unusedInheritedDirect;
+  }
+
+  public List<Entry> getUnusedInheritedTransitive() {
+    return unusedInheritedTransitive;
+  }
+
+  public List<Entry> getIgnored() {
+    return ignored;
+  }
+
+  /** The analysis settings that influence the result; a snapshot is only reusable if they match. */
+  public static final class Settings {
+
+    private final boolean ignoreTests;
+    private final Set<String> ignoreScopes;
+    private final Set<String> ignoreDependencies;
+
+    /** Creates the settings; both sets are copied into sorted sets. */
+    public Settings(
+        boolean ignoreTests, Collection<String> ignoreScopes, Collection<String> ignoreDependencies) {
+      this.ignoreTests = ignoreTests;
+      this.ignoreScopes = Collections.unmodifiableSet(new TreeSet<>(ignoreScopes));
+      this.ignoreDependencies = Collections.unmodifiableSet(new TreeSet<>(ignoreDependencies));
+    }
+
+    public boolean isIgnoreTests() {
+      return ignoreTests;
+    }
+
+    public Set<String> getIgnoreScopes() {
+      return ignoreScopes;
+    }
+
+    public Set<String> getIgnoreDependencies() {
+      return ignoreDependencies;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Settings)) {
+        return false;
+      }
+      Settings that = (Settings) o;
+      return ignoreTests == that.ignoreTests
+          && ignoreScopes.equals(that.ignoreScopes)
+          && ignoreDependencies.equals(that.ignoreDependencies);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(ignoreTests, ignoreScopes, ignoreDependencies);
+    }
+  }
+
+  /** One dependency of the analysed project. */
+  public static final class Entry {
+
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+    @Nullable private final String scope;
+    private final long sizeBytes;
+    private final int totalClasses;
+    private final List<String> usedClasses;
+
+    /** Creates an entry. */
+    public Entry(
+        String groupId,
+        String artifactId,
+        String version,
+        @Nullable String scope,
+        long sizeBytes,
+        int totalClasses,
+        Collection<String> usedClasses) {
+      this.groupId = groupId;
+      this.artifactId = artifactId;
+      this.version = version;
+      this.scope = scope;
+      this.sizeBytes = sizeBytes;
+      this.totalClasses = totalClasses;
+      this.usedClasses = Collections.unmodifiableList(new ArrayList<>(new TreeSet<>(usedClasses)));
+    }
+
+    static Entry from(Dependency dependency, @Nullable DependencyTypes types) {
+      int totalClasses = 0;
+      for (ClassName ignored : dependency.getRelatedClasses()) {
+        totalClasses++;
+      }
+      List<String> usedClasses =
+          types == null
+              ? Collections.emptyList()
+              : types.getUsedTypes().stream().map(ClassName::getValue).collect(Collectors.toList());
+      return new Entry(
+          dependency.getGroupId(),
+          dependency.getDependencyId(),
+          dependency.getVersion(),
+          dependency.getScope(),
+          dependency.getSize(),
+          totalClasses,
+          usedClasses);
+    }
+
+    public String getGroupId() {
+      return groupId;
+    }
+
+    public String getArtifactId() {
+      return artifactId;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    @Nullable
+    public String getScope() {
+      return scope;
+    }
+
+    public long getSizeBytes() {
+      return sizeBytes;
+    }
+
+    public int getTotalClasses() {
+      return totalClasses;
+    }
+
+    public List<String> getUsedClasses() {
+      return usedClasses;
+    }
+
+    /** The {@code groupId:artifactId:version} coordinate. */
+    public String coordinate() {
+      return groupId + ":" + artifactId + ":" + version;
+    }
+  }
+}

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisSnapshotFile.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisSnapshotFile.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, CASTOR Software Research Centre (www.castor.kth.se)
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package se.kth.depclean.report;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reads and writes the {@code depclean-analysis.json} file that lets {@code depclean:report} reuse
+ * the analysis produced earlier in the build by {@code depclean:depclean}.
+ */
+public final class AnalysisSnapshotFile {
+
+  /** Name of the file, located in the project build directory. */
+  public static final String FILE_NAME = "depclean-analysis.json";
+
+  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+  private final Path file;
+
+  /** Creates the accessor for the snapshot in the given build directory. */
+  public AnalysisSnapshotFile(Path buildDirectory) {
+    this.file = buildDirectory.resolve(FILE_NAME);
+  }
+
+  public Path getPath() {
+    return file;
+  }
+
+  /** Writes the snapshot, replacing any previous one. */
+  public void write(AnalysisSnapshot snapshot) throws IOException {
+    Files.createDirectories(file.getParent());
+    try (Writer writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+      GSON.toJson(snapshot, writer);
+    }
+  }
+
+  /**
+   * Returns the stored snapshot if it can still be trusted: it exists, was produced with the same
+   * settings, and is not older than the POM or any compiled class it was computed from.
+   *
+   * @param settings the settings the caller would analyze with
+   * @param pom the project POM
+   * @param classDirectories the compiled main and test class directories
+   */
+  public Optional<AnalysisSnapshot> readIfFresh(
+      AnalysisSnapshot.Settings settings, Path pom, Collection<Path> classDirectories)
+      throws IOException {
+    if (!Files.isRegularFile(file)) {
+      return Optional.empty();
+    }
+    FileTime snapshotTime = Files.getLastModifiedTime(file);
+    if (isNewerThan(pom, snapshotTime)) {
+      return Optional.empty();
+    }
+    for (Path directory : classDirectories) {
+      if (Files.isDirectory(directory) && containsFileNewerThan(directory, snapshotTime)) {
+        return Optional.empty();
+      }
+    }
+    AnalysisSnapshot snapshot = read();
+    if (snapshot == null || !settings.equals(snapshot.getSettings())) {
+      return Optional.empty();
+    }
+    return Optional.of(snapshot);
+  }
+
+  @Nullable
+  private AnalysisSnapshot read() throws IOException {
+    try (Reader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+      return GSON.fromJson(reader, AnalysisSnapshot.class);
+    } catch (JsonParseException e) {
+      // A corrupt or incompatible file is simply not reusable
+      return null;
+    }
+  }
+
+  private static boolean containsFileNewerThan(Path directory, FileTime time) throws IOException {
+    try (Stream<Path> files = Files.walk(directory)) {
+      return files.filter(Files::isRegularFile).anyMatch(path -> isNewerThan(path, time));
+    }
+  }
+
+  private static boolean isNewerThan(Path path, FileTime time) {
+    try {
+      return Files.getLastModifiedTime(path).compareTo(time) > 0;
+    } catch (IOException e) {
+      return true;
+    }
+  }
+}

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisSnapshotFile.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/report/AnalysisSnapshotFile.java
@@ -26,10 +26,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileTime;
-import java.util.Collection;
 import java.util.Optional;
-import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -64,29 +61,20 @@ public final class AnalysisSnapshotFile {
 
   /**
    * Returns the stored snapshot if it can still be trusted: it exists, was produced with the same
-   * settings, and is not older than the POM or any compiled class it was computed from.
+   * settings, and from the same POM and compiled classes (see {@link AnalysisInputs}).
    *
    * @param settings the settings the caller would analyze with
-   * @param pom the project POM
-   * @param classDirectories the compiled main and test class directories
+   * @param inputsFingerprint the fingerprint of the inputs the caller would analyze
    */
   public Optional<AnalysisSnapshot> readIfFresh(
-      AnalysisSnapshot.Settings settings, Path pom, Collection<Path> classDirectories)
-      throws IOException {
+      AnalysisSnapshot.Settings settings, String inputsFingerprint) throws IOException {
     if (!Files.isRegularFile(file)) {
       return Optional.empty();
     }
-    FileTime snapshotTime = Files.getLastModifiedTime(file);
-    if (isNewerThan(pom, snapshotTime)) {
-      return Optional.empty();
-    }
-    for (Path directory : classDirectories) {
-      if (Files.isDirectory(directory) && containsFileNewerThan(directory, snapshotTime)) {
-        return Optional.empty();
-      }
-    }
     AnalysisSnapshot snapshot = read();
-    if (snapshot == null || !settings.equals(snapshot.getSettings())) {
+    if (snapshot == null
+        || !settings.equals(snapshot.getSettings())
+        || !inputsFingerprint.equals(snapshot.getInputsFingerprint())) {
       return Optional.empty();
     }
     return Optional.of(snapshot);
@@ -99,20 +87,6 @@ public final class AnalysisSnapshotFile {
     } catch (JsonParseException e) {
       // A corrupt or incompatible file is simply not reusable
       return null;
-    }
-  }
-
-  private static boolean containsFileNewerThan(Path directory, FileTime time) throws IOException {
-    try (Stream<Path> files = Files.walk(directory)) {
-      return files.filter(Files::isRegularFile).anyMatch(path -> isNewerThan(path, time));
-    }
-  }
-
-  private static boolean isNewerThan(Path path, FileTime time) {
-    try {
-      return Files.getLastModifiedTime(path).compareTo(time) > 0;
-    } catch (IOException e) {
-      return true;
     }
   }
 }

--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/report/DepCleanReportRenderer.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/report/DepCleanReportRenderer.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2020, CASTOR Software Research Centre (www.castor.kth.se)
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package se.kth.depclean.report;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.reporting.AbstractMavenReportRenderer;
+import se.kth.depclean.report.AnalysisSnapshot.Entry;
+
+/** Renders an {@link AnalysisSnapshot} as a Doxia document, i.e. the body of the DepClean site page. */
+public final class DepCleanReportRenderer extends AbstractMavenReportRenderer {
+
+  private static final String[] DEPENDENCY_TABLE_HEADER = {
+    "Group ID", "Artifact ID", "Version", "Scope", "Size", "Used classes"
+  };
+
+  private final AnalysisSnapshot snapshot;
+  private final String projectName;
+  private final boolean reused;
+  private final List<Category> categories;
+
+  /**
+   * Creates the renderer.
+   *
+   * @param sink the sink to render into
+   * @param snapshot the analysis result to render
+   * @param projectName the name (or coordinates) of the analysed project
+   * @param reused whether the result was reused from an earlier {@code depclean:depclean} run
+   */
+  public DepCleanReportRenderer(
+      Sink sink, AnalysisSnapshot snapshot, String projectName, boolean reused) {
+    super(sink);
+    this.snapshot = snapshot;
+    this.projectName = projectName;
+    this.reused = reused;
+    this.categories =
+        Arrays.asList(
+            new Category("Used direct dependencies", "used-direct", snapshot.getUsedDirect()),
+            new Category(
+                "Used transitive dependencies", "used-transitive", snapshot.getUsedTransitive()),
+            new Category(
+                "Used inherited direct dependencies",
+                "used-inherited-direct",
+                snapshot.getUsedInheritedDirect()),
+            new Category(
+                "Used inherited transitive dependencies",
+                "used-inherited-transitive",
+                snapshot.getUsedInheritedTransitive()),
+            new Category(
+                "Potentially unused direct dependencies",
+                "unused-direct",
+                snapshot.getUnusedDirect()),
+            new Category(
+                "Potentially unused transitive dependencies",
+                "unused-transitive",
+                snapshot.getUnusedTransitive()),
+            new Category(
+                "Potentially unused inherited direct dependencies",
+                "unused-inherited-direct",
+                snapshot.getUnusedInheritedDirect()),
+            new Category(
+                "Potentially unused inherited transitive dependencies",
+                "unused-inherited-transitive",
+                snapshot.getUnusedInheritedTransitive()),
+            new Category("Ignored dependencies", "ignored", snapshot.getIgnored()));
+  }
+
+  @Override
+  public String getTitle() {
+    return "DepClean Report";
+  }
+
+  @Override
+  protected void renderBody() {
+    startSection(getTitle(), "depclean");
+    renderIntroduction();
+    renderSummary();
+    for (Category category : categories) {
+      renderCategory(category);
+    }
+    renderDetails();
+    endSection();
+  }
+
+  private void renderIntroduction() {
+    paragraph(
+        "DepClean statically analyses the bytecode of "
+            + projectName
+            + " to detect the dependencies whose classes are never referenced by the project. Such"
+            + " dependencies are potentially unused: they are candidates for removal (direct"
+            + " dependencies) or exclusion (transitive dependencies).");
+    AnalysisSnapshot.Settings settings = snapshot.getSettings();
+    startTable();
+    tableRow(new String[] {"Test classes analysed", settings.isIgnoreTests() ? "no" : "yes"});
+    tableRow(new String[] {"Ignored scopes", joinOrNone(settings.getIgnoreScopes())});
+    tableRow(new String[] {"Ignored dependencies", joinOrNone(settings.getIgnoreDependencies())});
+    tableRow(
+        new String[] {
+          "Analysis result",
+          reused ? "reused from the depclean:depclean run of this build" : "computed by this report"
+        });
+    endTable();
+  }
+
+  private void renderSummary() {
+    startSection("Summary", "summary");
+    startTable();
+    tableHeader(new String[] {"Category", "Dependencies", "Total size"});
+    for (Category category : categories) {
+      tableRow(
+          new String[] {
+            createLinkPatternedText(category.title, "#" + category.anchor),
+            String.valueOf(category.entries.size()),
+            formatSize(category.entries.stream().mapToLong(Entry::getSizeBytes).sum())
+          });
+    }
+    endTable();
+    endSection();
+  }
+
+  private void renderCategory(Category category) {
+    startSection(category.title + " (" + category.entries.size() + ")", category.anchor);
+    if (category.entries.isEmpty()) {
+      paragraph("None.");
+    } else {
+      startTable();
+      tableHeader(DEPENDENCY_TABLE_HEADER);
+      for (Entry entry : category.entries) {
+        tableRow(
+            new String[] {
+              entry.getGroupId(),
+              entry.getArtifactId(),
+              entry.getVersion(),
+              entry.getScope(),
+              formatSize(entry.getSizeBytes()),
+              usedClassesCell(entry)
+            });
+      }
+      endTable();
+    }
+    endSection();
+  }
+
+  private String usedClassesCell(Entry entry) {
+    String ratio = entry.getUsedClasses().size() + " / " + entry.getTotalClasses();
+    return entry.getUsedClasses().isEmpty()
+        ? ratio
+        : createLinkPatternedText(ratio, "#" + detailsAnchor(entry));
+  }
+
+  private void renderDetails() {
+    List<Entry> usedEntries = new ArrayList<>();
+    for (Category category : categories) {
+      if (category.anchor.startsWith("used-")) {
+        usedEntries.addAll(category.entries);
+      }
+    }
+    startSection("Used classes per dependency", "details");
+    if (usedEntries.isEmpty()) {
+      paragraph("No dependency is used by the project.");
+    } else {
+      paragraph("The classes of each used dependency that the project references.");
+      for (Entry entry : usedEntries) {
+        renderDetailsOf(entry);
+      }
+    }
+    endSection();
+  }
+
+  private void renderDetailsOf(Entry entry) {
+    startSection(entry.coordinate(), detailsAnchor(entry));
+    paragraph(
+        entry.getUsedClasses().size()
+            + " of "
+            + entry.getTotalClasses()
+            + " classes used, "
+            + formatSize(entry.getSizeBytes())
+            + (entry.getScope() == null ? "" : ", scope " + entry.getScope()));
+    if (!entry.getUsedClasses().isEmpty()) {
+      sink.list();
+      for (String className : entry.getUsedClasses()) {
+        sink.listItem();
+        sink.monospaced();
+        text(className);
+        sink.monospaced_();
+        sink.listItem_();
+      }
+      sink.list_();
+    }
+    endSection();
+  }
+
+  private static String detailsAnchor(Entry entry) {
+    return "dep-" + entry.coordinate().replaceAll("[^A-Za-z0-9._-]", "_");
+  }
+
+  private static String formatSize(long bytes) {
+    return FileUtils.byteCountToDisplaySize(bytes);
+  }
+
+  private static String joinOrNone(Iterable<String> values) {
+    List<String> list = new ArrayList<>();
+    values.forEach(list::add);
+    return list.isEmpty() ? "none" : String.join(", ", list);
+  }
+
+  /** One of the dependency groups DepClean reports on. */
+  private static final class Category {
+    final String title;
+    final String anchor;
+    final List<Entry> entries;
+
+    Category(String title, String anchor, List<Entry> entries) {
+      this.title = title;
+      this.anchor = anchor;
+      this.entries = Collections.unmodifiableList(entries);
+    }
+  }
+}

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanReportMojoIT.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/DepCleanReportMojoIT.java
@@ -1,0 +1,123 @@
+package se.kth.depclean;
+
+import static com.soebes.itf.extension.assertj.MavenITAssertions.assertThat;
+
+import com.soebes.itf.jupiter.extension.MavenGoal;
+import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
+import com.soebes.itf.jupiter.extension.MavenTest;
+import com.soebes.itf.jupiter.maven.MavenExecutionResult;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.assertj.core.api.ListAssert;
+
+/**
+ * Integration tests for {@link DepCleanReportMojo}. The projects used for testing are in
+ * src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT.
+ */
+@MavenJupiterExtension
+public class DepCleanReportMojoIT {
+
+  private static final String MAVEN_4_STDOUT_PREFIX = "[INFO] [stdout] ";
+
+  @MavenTest
+  @MavenGoal("site")
+  void report_via_site(MavenExecutionResult result) throws IOException {
+    assertThat(result).isSuccessful();
+    Path site = targetDirectory(result).resolve("site");
+
+    String report = read(site.resolve("depclean.html"));
+    assertThat(report)
+        .contains("DepClean Report")
+        .contains("Used direct dependencies (1)")
+        .contains("<td>commons-io</td>")
+        .contains("Potentially unused direct dependencies (1)")
+        .contains("<td>commons-compress</td>")
+        .contains("Potentially unused transitive dependencies (2)")
+        .contains("<td>commons-lang3</td>")
+        .contains("<td>commons-codec</td>")
+        .contains("<code>org.apache.commons.io.FileUtils</code>")
+        .contains("computed by this report");
+
+    // The page is listed in the "Project Reports" section of the site
+    assertThat(read(site.resolve("project-reports.html")))
+        .contains("depclean.html")
+        .contains("DepClean");
+
+    // The report never touches the project or writes the depclean:depclean artifacts
+    Path project = targetDirectory(result).getParent();
+    assertThat(project.resolve("pom-debloated.xml")).doesNotExist();
+    assertThat(targetDirectory(result).resolve("depclean-results.json"))
+        .doesNotExist();
+    assertThat(targetDirectory(result).resolve("depclean-analysis.json"))
+        .exists();
+  }
+
+  @MavenTest
+  @MavenGoal("package")
+  @MavenGoal("depclean:report")
+  void report_reuses_analysis(MavenExecutionResult result) throws IOException {
+    assertThatStdout(result)
+        .anyMatch(line -> line.contains("Analysis snapshot written to"))
+        .anyMatch(line -> line.contains("Reusing the DepClean analysis from"))
+        // the DepClean banner is printed exactly once: by depclean:depclean, not by the report
+        .filteredOn(line -> line.contains("D E P C L E A N   A N A L Y S I S   R E S U L T S"))
+        .hasSize(1);
+
+    String report = read(targetDirectory(result).resolve("reports").resolve("depclean.html"));
+    assertThat(report)
+        .contains("reused from the depclean:depclean run")
+        .contains("<td>commons-compress</td>");
+  }
+
+  @MavenTest
+  @MavenGoal("depclean:report")
+  void report_recomputes_when_stale(MavenExecutionResult result) throws IOException {
+    assertThatStdout(result)
+        .noneMatch(line -> line.contains("Reusing the DepClean analysis from"))
+        .contains(
+            "USED DIRECT DEPENDENCIES [1]: ",
+            "POTENTIALLY UNUSED DIRECT DEPENDENCIES [1]: ",
+            "POTENTIALLY UNUSED TRANSITIVE DEPENDENCIES [2]: ");
+
+    String report = read(targetDirectory(result).resolve("reports").resolve("depclean.html"));
+    assertThat(report)
+        .contains("computed by this report")
+        .contains("<td>commons-compress</td>");
+  }
+
+  private static Path targetDirectory(MavenExecutionResult result) {
+    File project = result.getMavenProjectResult().getTargetProjectDirectory().toFile();
+    return project.toPath().resolve("target");
+  }
+
+  private static String read(Path file) throws IOException {
+    assertThat(file).isRegularFile();
+    return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+  }
+
+  /** Asserts that the build succeeded and returns its standard output, normalized across Maven versions. */
+  private static ListAssert<String> assertThatStdout(MavenExecutionResult result) {
+    assertThat(result).isSuccessful();
+    try {
+      List<String> lines =
+          Files.readAllLines(result.getMavenLog().getStdout(), StandardCharsets.UTF_8).stream()
+              .map(DepCleanReportMojoIT::withoutStdoutPrefix)
+              .collect(Collectors.toList());
+      return assertThat(lines);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static String withoutStdoutPrefix(String line) {
+    return line.startsWith(MAVEN_4_STDOUT_PREFIX)
+        ? line.substring(MAVEN_4_STDOUT_PREFIX.length())
+        : line;
+  }
+}

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/report/AnalysisInputsTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/report/AnalysisInputsTest.java
@@ -1,0 +1,102 @@
+package se.kth.depclean.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link AnalysisInputs}. */
+class AnalysisInputsTest {
+
+  @TempDir Path projectDir;
+
+  private Path pom;
+  private Path classes;
+  private Path testClasses;
+  private List<Path> classDirectories;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    pom = write(projectDir.resolve("pom.xml"), "<project/>");
+    classes = Files.createDirectories(projectDir.resolve("target/classes"));
+    testClasses = Files.createDirectories(projectDir.resolve("target/test-classes"));
+    write(classes.resolve("Foo.class"), "foo");
+    write(classes.resolve("sub/Bar.class"), "bar");
+    write(testClasses.resolve("FooTest.class"), "foo-test");
+    classDirectories = Arrays.asList(classes, testClasses);
+  }
+
+  @Test
+  void isStableAcrossRuns() throws IOException {
+    assertThat(fingerprint()).isEqualTo(fingerprint()).hasSize(64).matches("[0-9a-f]+");
+  }
+
+  @Test
+  void ignoresTimestampsOfUnchangedFiles() throws IOException {
+    String before = fingerprint();
+    // What a forked lifecycle does when it recompiles identical sources
+    Files.setLastModifiedTime(
+        classes.resolve("Foo.class"), FileTime.from(Instant.parse("2030-01-01T00:00:00Z")));
+
+    assertThat(fingerprint()).isEqualTo(before);
+  }
+
+  @Test
+  void changesWhenPomChanges() throws IOException {
+    String before = fingerprint();
+    write(pom, "<project><name>changed</name></project>");
+
+    assertThat(fingerprint()).isNotEqualTo(before);
+  }
+
+  @Test
+  void changesWhenAClassChanges() throws IOException {
+    String before = fingerprint();
+    write(testClasses.resolve("FooTest.class"), "changed");
+
+    assertThat(fingerprint()).isNotEqualTo(before);
+  }
+
+  @Test
+  void changesWhenAClassIsAddedOrMoved() throws IOException {
+    String before = fingerprint();
+    write(classes.resolve("Baz.class"), "baz");
+    String added = fingerprint();
+    Files.move(classes.resolve("Baz.class"), classes.resolve("sub/Baz.class"));
+
+    assertThat(added).isNotEqualTo(before);
+    assertThat(fingerprint()).isNotEqualTo(before).isNotEqualTo(added);
+  }
+
+  @Test
+  void ignoresNonClassFilesAndMissingDirectories() throws IOException {
+    String before = fingerprint();
+    write(classes.resolve("application.properties"), "key=value");
+
+    assertThat(fingerprint()).isEqualTo(before);
+    assertThat(
+            AnalysisInputs.fingerprint(
+                pom, Arrays.asList(classes, testClasses, projectDir.resolve("does-not-exist"))))
+        .isEqualTo(before);
+    assertThat(AnalysisInputs.fingerprint(pom, Collections.emptyList())).isNotEqualTo(before);
+  }
+
+  private String fingerprint() throws IOException {
+    return AnalysisInputs.fingerprint(pom, classDirectories);
+  }
+
+  private static Path write(Path file, String content) throws IOException {
+    Files.createDirectories(file.getParent());
+    return Files.write(file, content.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/report/AnalysisInputsTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/report/AnalysisInputsTest.java
@@ -79,6 +79,19 @@ class AnalysisInputsTest {
   }
 
   @Test
+  void ignoresTestClassesWhenTestsAreIgnored() throws IOException {
+    List<Path> withoutTests = AnalysisInputs.classDirectories(classes, testClasses, true);
+    assertThat(withoutTests).containsExactly(classes);
+    assertThat(AnalysisInputs.classDirectories(classes, testClasses, false))
+        .containsExactly(classes, testClasses);
+
+    String before = AnalysisInputs.fingerprint(pom, withoutTests);
+    write(testClasses.resolve("FooTest.class"), "changed");
+
+    assertThat(AnalysisInputs.fingerprint(pom, withoutTests)).isEqualTo(before);
+  }
+
+  @Test
   void ignoresNonClassFilesAndMissingDirectories() throws IOException {
     String before = fingerprint();
     write(classes.resolve("application.properties"), "key=value");

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/report/AnalysisSnapshotFileTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/report/AnalysisSnapshotFileTest.java
@@ -1,0 +1,153 @@
+package se.kth.depclean.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link AnalysisSnapshotFile}. */
+class AnalysisSnapshotFileTest {
+
+  private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+  @TempDir Path projectDir;
+
+  private Path pom;
+  private Path classes;
+  private Path testClasses;
+  private AnalysisSnapshotFile snapshotFile;
+  private AnalysisSnapshot.Settings settings;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    pom = Files.write(projectDir.resolve("pom.xml"), "<project/>".getBytes("UTF-8"));
+    Path target = projectDir.resolve("target");
+    classes = Files.createDirectories(target.resolve("classes"));
+    testClasses = Files.createDirectories(target.resolve("test-classes"));
+    Files.createFile(classes.resolve("Foo.class"));
+    Files.createFile(testClasses.resolve("FooTest.class"));
+    snapshotFile = new AnalysisSnapshotFile(target);
+    settings =
+        new AnalysisSnapshot.Settings(
+            true, Collections.singleton("provided"), Arrays.asList("com.google.guava.*"));
+    // Everything the snapshot depends on predates the snapshot written by the tests
+    for (Path path : Arrays.asList(pom, classes.resolve("Foo.class"), testClasses.resolve("FooTest.class"))) {
+      Files.setLastModifiedTime(path, FileTime.from(T0));
+    }
+  }
+
+  @Test
+  void roundTripPreservesEntriesAndSettings() throws IOException {
+    AnalysisSnapshot original = snapshot(settings);
+
+    snapshotFile.write(original);
+    Optional<AnalysisSnapshot> read = readFresh(settings);
+
+    assertThat(read).isPresent();
+    AnalysisSnapshot snapshot = read.get();
+    assertThat(snapshot.getSettings()).isEqualTo(settings);
+    assertThat(snapshot.getUsedDirect()).hasSize(1);
+    AnalysisSnapshot.Entry used = snapshot.getUsedDirect().get(0);
+    assertThat(used.coordinate()).isEqualTo("commons-io:commons-io:2.22.0");
+    assertThat(used.getScope()).isEqualTo("compile");
+    assertThat(used.getSizeBytes()).isEqualTo(608_000L);
+    assertThat(used.getTotalClasses()).isEqualTo(300);
+    assertThat(used.getUsedClasses())
+        .containsExactly("org.apache.commons.io.FileUtils", "org.apache.commons.io.IOUtils");
+    assertThat(snapshot.getUnusedTransitive()).extracting(AnalysisSnapshot.Entry::getScope)
+        .containsExactly((String) null);
+    assertThat(snapshot.getIgnored()).isEmpty();
+  }
+
+  @Test
+  void isNotReusableWhenMissing() throws IOException {
+    assertThat(readFresh(settings)).isEmpty();
+  }
+
+  @Test
+  void isNotReusableWhenSettingsDiffer() throws IOException {
+    snapshotFile.write(snapshot(settings));
+
+    AnalysisSnapshot.Settings other =
+        new AnalysisSnapshot.Settings(false, Collections.emptySet(), Collections.emptySet());
+    assertThat(readFresh(other)).isEmpty();
+  }
+
+  @Test
+  void isNotReusableWhenPomIsNewer() throws IOException {
+    snapshotFile.write(snapshot(settings));
+    touchAfterSnapshot(pom);
+
+    assertThat(readFresh(settings)).isEmpty();
+  }
+
+  @Test
+  void isNotReusableWhenAClassIsNewer() throws IOException {
+    snapshotFile.write(snapshot(settings));
+    touchAfterSnapshot(testClasses.resolve("FooTest.class"));
+
+    assertThat(readFresh(settings)).isEmpty();
+  }
+
+  @Test
+  void isNotReusableWhenCorrupt() throws IOException {
+    Files.write(snapshotFile.getPath(), "{ not json".getBytes("UTF-8"));
+
+    assertThat(readFresh(settings)).isEmpty();
+  }
+
+  @Test
+  void ignoresMissingClassDirectories() throws IOException {
+    snapshotFile.write(snapshot(settings));
+
+    Optional<AnalysisSnapshot> read =
+        snapshotFile.readIfFresh(
+            settings, pom, Collections.singletonList(projectDir.resolve("does-not-exist")));
+
+    assertThat(read).isPresent();
+  }
+
+  private Optional<AnalysisSnapshot> readFresh(AnalysisSnapshot.Settings with) throws IOException {
+    return snapshotFile.readIfFresh(with, pom, Arrays.asList(classes, testClasses));
+  }
+
+  private void touchAfterSnapshot(Path path) throws IOException {
+    FileTime snapshotTime = Files.getLastModifiedTime(snapshotFile.getPath());
+    Files.setLastModifiedTime(path, FileTime.from(snapshotTime.toInstant().plusSeconds(5)));
+  }
+
+  static AnalysisSnapshot snapshot(AnalysisSnapshot.Settings settings) {
+    AnalysisSnapshot.Entry used =
+        new AnalysisSnapshot.Entry(
+            "commons-io",
+            "commons-io",
+            "2.22.0",
+            "compile",
+            608_000L,
+            300,
+            Arrays.asList("org.apache.commons.io.IOUtils", "org.apache.commons.io.FileUtils"));
+    AnalysisSnapshot.Entry unused =
+        new AnalysisSnapshot.Entry(
+            "commons-codec", "commons-codec", "1.19.0", null, 373_000L, 120, Collections.emptyList());
+    return new AnalysisSnapshot(
+        settings,
+        Collections.singletonList(used),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.singletonList(unused),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList());
+  }
+}

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/report/AnalysisSnapshotFileTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/report/AnalysisSnapshotFileTest.java
@@ -5,8 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileTime;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -17,44 +15,32 @@ import org.junit.jupiter.api.io.TempDir;
 /** Unit tests for {@link AnalysisSnapshotFile}. */
 class AnalysisSnapshotFileTest {
 
-  private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+  private static final String FINGERPRINT = "0123abcd";
 
-  @TempDir Path projectDir;
+  @TempDir Path target;
 
-  private Path pom;
-  private Path classes;
-  private Path testClasses;
   private AnalysisSnapshotFile snapshotFile;
   private AnalysisSnapshot.Settings settings;
 
   @BeforeEach
-  void setUp() throws IOException {
-    pom = Files.write(projectDir.resolve("pom.xml"), "<project/>".getBytes("UTF-8"));
-    Path target = projectDir.resolve("target");
-    classes = Files.createDirectories(target.resolve("classes"));
-    testClasses = Files.createDirectories(target.resolve("test-classes"));
-    Files.createFile(classes.resolve("Foo.class"));
-    Files.createFile(testClasses.resolve("FooTest.class"));
+  void setUp() {
     snapshotFile = new AnalysisSnapshotFile(target);
     settings =
         new AnalysisSnapshot.Settings(
             true, Collections.singleton("provided"), Arrays.asList("com.google.guava.*"));
-    // Everything the snapshot depends on predates the snapshot written by the tests
-    for (Path path : Arrays.asList(pom, classes.resolve("Foo.class"), testClasses.resolve("FooTest.class"))) {
-      Files.setLastModifiedTime(path, FileTime.from(T0));
-    }
   }
 
   @Test
-  void roundTripPreservesEntriesAndSettings() throws IOException {
+  void roundTripPreservesEntriesSettingsAndFingerprint() throws IOException {
     AnalysisSnapshot original = snapshot(settings);
 
     snapshotFile.write(original);
-    Optional<AnalysisSnapshot> read = readFresh(settings);
+    Optional<AnalysisSnapshot> read = snapshotFile.readIfFresh(settings, FINGERPRINT);
 
     assertThat(read).isPresent();
     AnalysisSnapshot snapshot = read.get();
     assertThat(snapshot.getSettings()).isEqualTo(settings);
+    assertThat(snapshot.getInputsFingerprint()).isEqualTo(FINGERPRINT);
     assertThat(snapshot.getUsedDirect()).hasSize(1);
     AnalysisSnapshot.Entry used = snapshot.getUsedDirect().get(0);
     assertThat(used.coordinate()).isEqualTo("commons-io:commons-io:2.22.0");
@@ -63,14 +49,15 @@ class AnalysisSnapshotFileTest {
     assertThat(used.getTotalClasses()).isEqualTo(300);
     assertThat(used.getUsedClasses())
         .containsExactly("org.apache.commons.io.FileUtils", "org.apache.commons.io.IOUtils");
-    assertThat(snapshot.getUnusedTransitive()).extracting(AnalysisSnapshot.Entry::getScope)
+    assertThat(snapshot.getUnusedTransitive())
+        .extracting(AnalysisSnapshot.Entry::getScope)
         .containsExactly((String) null);
     assertThat(snapshot.getIgnored()).isEmpty();
   }
 
   @Test
   void isNotReusableWhenMissing() throws IOException {
-    assertThat(readFresh(settings)).isEmpty();
+    assertThat(snapshotFile.readIfFresh(settings, FINGERPRINT)).isEmpty();
   }
 
   @Test
@@ -79,50 +66,33 @@ class AnalysisSnapshotFileTest {
 
     AnalysisSnapshot.Settings other =
         new AnalysisSnapshot.Settings(false, Collections.emptySet(), Collections.emptySet());
-    assertThat(readFresh(other)).isEmpty();
+    assertThat(snapshotFile.readIfFresh(other, FINGERPRINT)).isEmpty();
   }
 
   @Test
-  void isNotReusableWhenPomIsNewer() throws IOException {
+  void isNotReusableWhenInputsChanged() throws IOException {
     snapshotFile.write(snapshot(settings));
-    touchAfterSnapshot(pom);
 
-    assertThat(readFresh(settings)).isEmpty();
-  }
-
-  @Test
-  void isNotReusableWhenAClassIsNewer() throws IOException {
-    snapshotFile.write(snapshot(settings));
-    touchAfterSnapshot(testClasses.resolve("FooTest.class"));
-
-    assertThat(readFresh(settings)).isEmpty();
+    assertThat(snapshotFile.readIfFresh(settings, "different")).isEmpty();
   }
 
   @Test
   void isNotReusableWhenCorrupt() throws IOException {
     Files.write(snapshotFile.getPath(), "{ not json".getBytes("UTF-8"));
 
-    assertThat(readFresh(settings)).isEmpty();
+    assertThat(snapshotFile.readIfFresh(settings, FINGERPRINT)).isEmpty();
   }
 
   @Test
-  void ignoresMissingClassDirectories() throws IOException {
-    snapshotFile.write(snapshot(settings));
+  void isNotReusableWhenWrittenByAnOlderVersionWithoutFingerprint() throws IOException {
+    Files.write(
+        snapshotFile.getPath(),
+        "{\"settings\":{\"ignoreTests\":false,\"ignoreScopes\":[],\"ignoreDependencies\":[]}}"
+            .getBytes("UTF-8"));
 
-    Optional<AnalysisSnapshot> read =
-        snapshotFile.readIfFresh(
-            settings, pom, Collections.singletonList(projectDir.resolve("does-not-exist")));
-
-    assertThat(read).isPresent();
-  }
-
-  private Optional<AnalysisSnapshot> readFresh(AnalysisSnapshot.Settings with) throws IOException {
-    return snapshotFile.readIfFresh(with, pom, Arrays.asList(classes, testClasses));
-  }
-
-  private void touchAfterSnapshot(Path path) throws IOException {
-    FileTime snapshotTime = Files.getLastModifiedTime(snapshotFile.getPath());
-    Files.setLastModifiedTime(path, FileTime.from(snapshotTime.toInstant().plusSeconds(5)));
+    AnalysisSnapshot.Settings plain =
+        new AnalysisSnapshot.Settings(false, Collections.emptySet(), Collections.emptySet());
+    assertThat(snapshotFile.readIfFresh(plain, FINGERPRINT)).isEmpty();
   }
 
   static AnalysisSnapshot snapshot(AnalysisSnapshot.Settings settings) {
@@ -137,9 +107,16 @@ class AnalysisSnapshotFileTest {
             Arrays.asList("org.apache.commons.io.IOUtils", "org.apache.commons.io.FileUtils"));
     AnalysisSnapshot.Entry unused =
         new AnalysisSnapshot.Entry(
-            "commons-codec", "commons-codec", "1.19.0", null, 373_000L, 120, Collections.emptyList());
+            "commons-codec",
+            "commons-codec",
+            "1.19.0",
+            null,
+            373_000L,
+            120,
+            Collections.emptyList());
     return new AnalysisSnapshot(
         settings,
+        FINGERPRINT,
         Collections.singletonList(used),
         Collections.emptyList(),
         Collections.emptyList(),

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/report/DepCleanReportRendererTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/report/DepCleanReportRendererTest.java
@@ -1,0 +1,87 @@
+package se.kth.depclean.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import org.apache.maven.doxia.module.xhtml5.Xhtml5SinkFactory;
+import org.apache.maven.doxia.sink.Sink;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link DepCleanReportRenderer}. */
+class DepCleanReportRendererTest {
+
+  private static final AnalysisSnapshot.Settings SETTINGS =
+      new AnalysisSnapshot.Settings(
+          true, Collections.singleton("provided"), Collections.singleton("com.google.guava.*"));
+
+  @Test
+  void rendersSummaryCategoriesAndDetails() throws IOException {
+    String html = render(AnalysisSnapshotFileTest.snapshot(SETTINGS), "foobar", true);
+
+    assertThat(html)
+        .contains("<title>DepClean Report</title>")
+        .contains("analyses the bytecode of foobar")
+        .contains("reused from the depclean:depclean run")
+        .contains("provided")
+        .contains("com.google.guava.*")
+        // summary links to the category sections
+        .contains("<a href=\"#unused-transitive\">Potentially unused transitive dependencies</a>")
+        .contains("<a id=\"used-direct\"></a>")
+        .contains("Used direct dependencies (1)")
+        .contains("Potentially unused transitive dependencies (1)")
+        .contains("Potentially unused direct dependencies (0)")
+        .contains("<td>commons-io</td>")
+        .contains("<td>2.22.0</td>")
+        .contains("<td>compile</td>")
+        .contains("<td>593 KB</td>")
+        // a missing scope renders as a dash instead of "null"
+        .contains("<td>-</td>")
+        .doesNotContain("null")
+        // used-class ratio links to the per-dependency details
+        .contains("<a href=\"#dep-commons-io_commons-io_2.22.0\">2 / 300</a>")
+        .contains("<a id=\"dep-commons-io_commons-io_2.22.0\"></a>")
+        .contains("<code>org.apache.commons.io.FileUtils</code>")
+        .contains("<code>org.apache.commons.io.IOUtils</code>");
+    // unused dependencies have no details section
+    assertThat(html).doesNotContain("dep-commons-codec");
+    // sections appear in the documented order
+    assertThat(html.indexOf("Summary"))
+        .isLessThan(html.indexOf("Used direct dependencies (1)"))
+        .isLessThan(html.indexOf("Used classes per dependency"));
+  }
+
+  @Test
+  void rendersEmptyAnalysis() throws IOException {
+    AnalysisSnapshot empty =
+        new AnalysisSnapshot(
+            new AnalysisSnapshot.Settings(false, Collections.emptySet(), Collections.emptySet()),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
+
+    String html = render(empty, "empty", false);
+
+    assertThat(html)
+        .contains("computed by this report")
+        .contains("<td>none</td>")
+        .contains("None.")
+        .contains("No dependency is used by the project.");
+  }
+
+  private static String render(AnalysisSnapshot snapshot, String projectName, boolean reused)
+      throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Sink sink = new Xhtml5SinkFactory().createSink(out, StandardCharsets.UTF_8.name());
+    new DepCleanReportRenderer(sink, snapshot, projectName, reused).render();
+    return out.toString(StandardCharsets.UTF_8.name());
+  }
+}

--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/report/DepCleanReportRendererTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/report/DepCleanReportRendererTest.java
@@ -58,6 +58,7 @@ class DepCleanReportRendererTest {
     AnalysisSnapshot empty =
         new AnalysisSnapshot(
             new AnalysisSnapshot.Settings(false, Collections.emptySet(), Collections.emptySet()),
+            "fingerprint",
             Collections.emptyList(),
             Collections.emptyList(),
             Collections.emptyList(),

--- a/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_recomputes_when_stale/pom.xml
+++ b/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_recomputes_when_stale/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.foo.bar</groupId>
+    <artifactId>foobar</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>foobar</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.22.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Not bound to any phase: the report must analyse the project itself -->
+            <plugin>
+                <groupId>se.kth.castor</groupId>
+                <artifactId>depclean-maven-plugin</artifactId>
+                <version>${project.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_recomputes_when_stale/src/main/java/Greeter.java
+++ b/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_recomputes_when_stale/src/main/java/Greeter.java
@@ -1,0 +1,12 @@
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+
+/** Uses commons-io only; commons-compress stays unused. */
+public class Greeter {
+
+  public static void main(String[] args) throws IOException {
+    FileUtils.writeStringToFile(new File("greeting.txt"), "hello", StandardCharsets.UTF_8);
+  }
+}

--- a/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_reuses_analysis/pom.xml
+++ b/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_reuses_analysis/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.foo.bar</groupId>
+    <artifactId>foobar</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>foobar</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.22.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- depclean:depclean runs at package and leaves target/depclean-analysis.json behind -->
+            <plugin>
+                <groupId>se.kth.castor</groupId>
+                <artifactId>depclean-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>depclean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_reuses_analysis/src/main/java/Greeter.java
+++ b/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_reuses_analysis/src/main/java/Greeter.java
@@ -1,0 +1,12 @@
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+
+/** Uses commons-io only; commons-compress stays unused. */
+public class Greeter {
+
+  public static void main(String[] args) throws IOException {
+    FileUtils.writeStringToFile(new File("greeting.txt"), "hello", StandardCharsets.UTF_8);
+  }
+}

--- a/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_via_site/pom.xml
+++ b/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_via_site/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.foo.bar</groupId>
+    <artifactId>foobar</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>foobar</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.22.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- The report plugin version is resolved from here -->
+            <plugin>
+                <groupId>se.kth.castor</groupId>
+                <artifactId>depclean-maven-plugin</artifactId>
+                <version>${project.version}</version>
+            </plugin>
+            <!-- Doxia 2 reports need maven-site-plugin 3.20+; Maven 3.9 defaults to 3.12.1 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.22.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>se.kth.castor</groupId>
+                <artifactId>depclean-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>

--- a/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_via_site/src/main/java/Greeter.java
+++ b/depclean-maven-plugin/src/test/resources-its/se/kth/depclean/DepCleanReportMojoIT/report_via_site/src/main/java/Greeter.java
@@ -1,0 +1,12 @@
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+
+/** Uses commons-io only; commons-compress stays unused. */
+public class Greeter {
+
+  public static void main(String[] args) throws IOException {
+    FileUtils.writeStringToFile(new File("greeting.txt"), "hello", StandardCharsets.UTF_8);
+  }
+}

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -50,13 +50,13 @@ apply() {
 }
 
 # The README carries the version both in <plugin> snippets and in
-# `mvn se.kth.castor:depclean-maven-plugin:<version>:depclean` command lines.
+# `mvn se.kth.castor:depclean-maven-plugin:<version>:<goal>` command lines.
 set_readme() {
   local v=$1
   apply "$README" '<artifactId>depclean-maven-plugin</artifactId>' \
     "/<artifactId>depclean-maven-plugin<\/artifactId>/{n;s|<version>[^<]*</version>|<version>$v</version>|}"
-  apply "$README" 'se\.kth\.castor:depclean-maven-plugin:[^:]+:depclean' \
-    "s|(se\.kth\.castor:depclean-maven-plugin:)[^:]+(:depclean)|\1$v\2|g"
+  apply "$README" 'se\.kth\.castor:depclean-maven-plugin:[^:]+:(depclean|report)' \
+    "s#(se\.kth\.castor:depclean-maven-plugin:)[^:]+(:(depclean|report))#\1$v\2#g"
 }
 
 # Version the README currently documents (first <plugin> snippet).


### PR DESCRIPTION
Closes #478.

## What

Adds a `depclean:report` goal built on the Maven Reporting API (`maven-reporting-impl` 4.0.0 / Doxia 2) that renders the DepClean analysis as `target/site/depclean.html`, listed in the site's **Project Reports** section.

The page contains:
- the settings the analysis ran with (`ignoreTests`, `ignoreScopes`, `ignoreDependencies`) and whether the result was reused or freshly computed;
- a **Summary** table (count + total size per category) linking to each section;
- one table per category — used / potentially unused × direct / transitive / inherited direct / inherited transitive, plus the dependencies ignored by configuration — with group id, artifact id, version, scope, size and `used / total` classes;
- a **Used classes per dependency** section listing the classes the project actually references from each used dependency.

## How

- `DepCleanReportMojo extends AbstractMavenReport`, `@Execute(phase = TEST_COMPILE)`, so a bare `mvn site` works without a prior build. It is read-only: never writes `pom-debloated.xml`, never applies `failIfUnused*`; skips cleanly for `skipDepClean` and `pom` packaging.
- **Reuse instead of analysing twice:** `depclean:depclean` now always writes a small gson snapshot to `target/depclean-analysis.json`. The report reuses it only when the settings match and the snapshot's fingerprint still matches — the SHA-256 of the POM, of every compiled class under `target/classes` / `target/test-classes`, and of the coordinates of the resolved dependencies. A recompile that reproduces identical inputs does not invalidate it, while a dependency version that changes (also through a parent POM, an activated settings profile or a command line property) does. Otherwise the report analyses itself and writes the snapshot. A file handoff was chosen over `MavenProject` context values because `maven-site-plugin` loads report plugins in their own ClassRealm, so in-memory `ProjectDependencyAnalysis` instances would not be type-compatible across goals.
- `DepCleanReportRenderer extends AbstractMavenReportRenderer` (Doxia sink, no HTML templates).
- `ignoreDependencies` / `ignoreScopes` / `ignoreTests` / `skipDepClean` are shared with the `depclean` goal under the same property names.

## Compatibility

- Runtime floor stays **Java 8**: the reporting/Doxia jars pass the existing `enforceBytecodeVersion` rule, and `runtime-smoke` now also runs `depclean:report` on JDK 8/17/21/25 (verified locally with a real JDK 8 runtime).
- Requires `maven-site-plugin` >= 3.20.0 (Doxia 2). Maven 3.9 still defaults to 3.12.1, so users must pin a recent version — documented in the README. Maven 4 (default site plugin 4.0.0-M16) works out of the box; the site IT passes on both 3.9.16 and 4.0.0-rc-6.

## Usage

```xml
<reporting>
  <plugins>
    <plugin>
      <groupId>se.kth.castor</groupId>
      <artifactId>depclean-maven-plugin</artifactId>
      <version>${depclean.version}</version>
      <reportSets>
        <reportSet>
          <reports>
            <report>report</report>
          </reports>
        </reportSet>
      </reportSets>
    </plugin>
  </plugins>
</reporting>
```

`mvn site` -> `target/site/depclean.html`; standalone `mvn se.kth.castor:depclean-maven-plugin:<v>:report` -> `target/reports/depclean.html`.

## Tests

- Unit: `AnalysisSnapshotFileTest` (round trip; freshness: missing / newer pom / newer class / different settings / corrupt file), `DepCleanReportRendererTest` (renders through `Xhtml5Sink`, asserts structure, anchors, `-` for a null scope, empty analysis).
- IT (`DepCleanReportMojoIT`): `report_via_site` (`mvn site`, page listed in `project-reports.html`, no `pom-debloated.xml`), `report_reuses_analysis` (`package depclean:report` reuses the snapshot, banner printed once), `report_recomputes_when_stale` (standalone report analyses itself).
- `./mvnw -ntp clean verify --errors` green; `scripts/set-version.sh --check` green (the script now also tracks the `:report` command line in the README).



---
Supersedes #540, which GitHub auto-closed when the fork was re-created (same commits, same branch).

